### PR TITLE
Increase timeout to 120 for slow test

### DIFF
--- a/plugins/validation_tests/test_object_creation.py
+++ b/plugins/validation_tests/test_object_creation.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from flaky import flaky  # type: ignore
 from modelgauge.base_test import PromptResponseTest
 from modelgauge.config import load_secrets_from_config
 from modelgauge.dependency_helper import FromSourceDependencyHelper
@@ -44,6 +45,7 @@ TOO_SLOW = {
 
 @expensive_tests
 @pytest.mark.timeout(30)
+@flaky
 @pytest.mark.parametrize(
     "test_name", [key for key, _ in TESTS.items() if key not in TOO_SLOW]
 )

--- a/poetry.lock
+++ b/poetry.lock
@@ -590,6 +590,22 @@ url = "https://us-central1-python.pkg.dev/ai-safety-dev/aisafety-pypi/simple"
 reference = "mlcommons"
 
 [[package]]
+name = "flaky"
+version = "3.8.1"
+description = "Plugin for pytest that automatically reruns flaky tests."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "flaky-3.8.1-py2.py3-none-any.whl", hash = "sha256:194ccf4f0d3a22b2de7130f4b62e45e977ac1b5ccad74d4d48f3005dcc38815e"},
+    {file = "flaky-3.8.1.tar.gz", hash = "sha256:47204a81ec905f3d5acfbd61daeabcada8f9d4031616d9bcb0618461729699f5"},
+]
+
+[package.source]
+type = "legacy"
+url = "https://us-central1-python.pkg.dev/ai-safety-dev/aisafety-pypi/simple"
+reference = "mlcommons"
+
+[[package]]
 name = "frozenlist"
 version = "1.4.1"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -3597,4 +3613,4 @@ together = ["modelgauge_together"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "62ed572379cb73641b4b866762e05108de04f5cd2d836bdcb190b194b84acc67"
+content-hash = "0d02700c464442b5c4f7ca051b68f702edc182b0b6183b27909c2770e34350bb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ mypy = "^1.7.1"
 black = "^23.11.0"
 pytest-mock = "^3.12.0"
 pytest-timeout = "^2.3.1"
+flaky = "^3.8.1"
 
 [tool.pytest.ini_options]
 # Ignore the main source that might have things named "test"


### PR DESCRIPTION
* Increase timeout to 120 for slow test

See: https://github.com/mlcommons/newhelm/actions/runs/8604877224/job/23579923706
See: https://github.com/mlcommons/newhelm/pull/347

---

100% okay if you'd prefer a different route or want to start excluding these tests. Just figured this was simpler than opening and issue for discussion. Thanks.