### PR TITLE
Rename `list` method to not ghost the built in `list`.

### DIFF
--- a/modelgauge/main.py
+++ b/modelgauge/main.py
@@ -27,8 +27,8 @@ from modelgauge.test_registry import TESTS
 from typing import List, Optional
 
 
-@modelgauge_cli.command()
-def list() -> None:
+@modelgauge_cli.command(name="list")
+def list_command() -> None:
     """Overview of Plugins, Tests, and SUTs."""
     plugins = list_plugins()
     display_header(f"Plugin Modules: {len(plugins)}")


### PR DESCRIPTION
This should have no effect on the command line due to the `name` argument.