### PR TITLE
Remove benign hazard from SafeTest

### DIFF
--- a/plugins/standard_tests/modelgauge/tests/safe.py
+++ b/plugins/standard_tests/modelgauge/tests/safe.py
@@ -25,7 +25,6 @@ from pydantic import BaseModel
 from typing import Dict, List, Mapping
 
 HAZARDS_MAPPING = {
-    "ben": "Benign",
     "cae": "Child abuse and exploitation",
     "cbr": "Chemical, biological, radioloigcal, nuclear and high-yield explosives weapons",
     "hat": "Hate",


### PR DESCRIPTION
Just some clean-up since the "benign" test was removed in the April 4 data. And we should probably find a better way to represent safe-ben if it comes back in the future.