### PR TITLE
Add ReadTheDocs and MkDocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+mkdocs:
+  configuration: mkdocs.yml

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+## Hello world!

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,3 @@
-## Hello world!
+# ModelGauge
+
+ModelGauge is a library that performs evaluations for the [MLCommons AI Safety project](https://mlcommons.org/working-groups/ai-safety/ai-safety/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,14 +3,15 @@ repo_url: https://github.com/mlcommons/modelgauge/
 edit_uri: blob/main/docs/
 theme:
   name: readthedocs
-  highlightjs: false
 plugins:
   - search
 nav:
+  - index.md
   - dev_quick_start.md
-  - plugins.md
+  - prompt_response_tests.md
   - tutorial.md
   - tutorial_tests.md
   - tutorial_suts.md
-  - prompt_response_tests.md
+  - plugins.md
+  - design_philosophy.md
   - publishing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,16 @@
+site_name: ModelGauge
+repo_url: https://github.com/mlcommons/modelgauge/
+edit_uri: blob/main/docs/
+theme:
+  name: readthedocs
+  highlightjs: false
+plugins:
+  - search
+nav:
+  - dev_quick_start.md
+  - plugins.md
+  - tutorial.md
+  - tutorial_tests.md
+  - tutorial_suts.md
+  - prompt_response_tests.md
+  - publishing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: ModelGauge
 repo_url: https://github.com/mlcommons/modelgauge/
 edit_uri: blob/main/docs/
 theme:
-  name: readthedocs
+  name: readthedocsgit st
 plugins:
   - search
 nav:


### PR DESCRIPTION
Add initial configuration files required to render the website on ReadTheDocs.

The placeholder front page will eventually be replaced with the contents of README.md.