### PR TITLE
Fix typo in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: ModelGauge
 repo_url: https://github.com/mlcommons/modelgauge/
 edit_uri: blob/main/docs/
 theme:
-  name: readthedocsgit st
+  name: readthedocs
 plugins:
   - search
 nav:


### PR DESCRIPTION
Fix typo caused by careless keyboard mashing.