### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -9,7 +9,7 @@ To discover plugins, ModelGauge searches special namespaces within `modelgauge`.
 * Files defining a Test should go in the `modelgauge.tests` namespace.
 * Files defining a SUT should go in the `modelgauge.suts` namespace.
 
-The `load_plugins()` call will import all modules in all namespace directories. This makes any code in that module accessible via reflection (e.g. finding all subclasses of a base class) and will run [InstanceFactory.register](../modelgauge/instance_factory.py) calls. This lets the ModelGauge command line list all Tests/SUTs without having to edit any core library code.
+The `load_plugins()` call will import all modules in all namespace directories. This makes any code in that module accessible via reflection (e.g. finding all subclasses of a base class) and will run [InstanceFactory.register](https://github.com/mlcommons/modelgauge/blob/main/modelgauge/instance_factory.py) calls. This lets the ModelGauge command line list all Tests/SUTs without having to edit any core library code.
 
 ## Adding a plugin to a local checkout of ModelGauge
 

--- a/docs/tutorial_suts.md
+++ b/docs/tutorial_suts.md
@@ -6,7 +6,7 @@ We think the best way to learn from this tutorial is to use it to create your ow
 
 ## Creating a basic SUT
 
-[Demo: DemoYesNoSUT](../demo_plugin/modelgauge/suts/demo_01_yes_no_sut.py)
+[Demo: DemoYesNoSUT](https://github.com/mlcommons/modelgauge/blob/main/demo_plugin/modelgauge/suts/demo_01_yes_no_sut.py)
 
 Before you dive into creating more realistic SUTs, let's start with with a toy example: A SUT that only answers the question "Does this prompt have an even number of words?"
 
@@ -111,7 +111,7 @@ poetry run modelgauge run-test --test demo_01 --sut demo_yes_no
 
 ## SUTs that call an API
 
-[Demo: DemoRandomWords](../demo_plugin/modelgauge/suts/demo_02_secrets_and_options_sut.py)
+[Demo: DemoRandomWords](https://github.com/mlcommons/modelgauge/blob/main/demo_plugin/modelgauge/suts/demo_02_secrets_and_options_sut.py)
 
 We expect the most common way to define a SUT is as a wrapper around an existing API. To explore this kind of SUT implementation, lets assume we've recently created a `RandomWords` SUT and set up an API for users to call it.  To implement this SUT in ModelGauge we'll need to explore two new features: Secrets and SUT Options.
 
@@ -186,7 +186,7 @@ def translate_text_prompt(self, prompt: TextPrompt) -> DemoRandomWordsRequest:
 
 ## Reusing SUT classes
 
-[Demo: DemoConstantSUT](../demo_plugin/modelgauge/suts/demo_03_sut_with_args.py)
+[Demo: DemoConstantSUT](https://github.com/mlcommons/modelgauge/blob/main/demo_plugin/modelgauge/suts/demo_03_sut_with_args.py)
 
 Many APIs allow you to interact with different models as easily as switching a request parameter. For example, TogetherAI and OpenAI both take the `model`'s name in the request. To handle this situation, ModelGauge allows a single SUT class to be reused with different configuration. To illustrate, let's create a SUT that always returns a predefined response.
 

--- a/docs/tutorial_tests.md
+++ b/docs/tutorial_tests.md
@@ -6,7 +6,7 @@ We think the best way to learn from this tutorial is to use it to create your ow
 
 ## Creating a basic Test
 
-[Demo: DemoSimpleQATest](../demo_plugin/modelgauge/tests/demo_01_simple_qa_test.py)
+[Demo: DemoSimpleQATest](https://github.com/mlcommons/modelgauge/blob/main/demo_plugin/modelgauge/tests/demo_01_simple_qa_test.py)
 
 Let's say we want to create a Test where we send a bunch of questions to the SUT, and expect it to respond with specific answers. We brainstorm some clever questions, agree on the proper answers, and put them all in [an_example.jsonl](https://github.com/mlcommons/modelgauge/raw/main/demo_plugin/web_data/an_example.jsonl).
 
@@ -21,7 +21,7 @@ class DemoSimpleQATest(PromptResponseTest):
 We now have several abstract methods we need to define.
 
 ### 1. Make the test items
-The first phase in a PromptResponseTest is making the `TestItem`s. We want these to be our questions from `an_example.jsonl`. ModelGauge uses [DependencyHelper](../modelgauge/dependency_helper.py) to ensure good hygiene of data dependencies (e.g. versioning). So we first need to tell ModelGauge that we have a dependency on that file by listing it in `get_dependencies`:
+The first phase in a PromptResponseTest is making the `TestItem`s. We want these to be our questions from `an_example.jsonl`. ModelGauge uses [DependencyHelper](https://github.com/mlcommons/modelgauge/blob/main/modelgauge/dependency_helper.py) to ensure good hygiene of data dependencies (e.g. versioning). So we first need to tell ModelGauge that we have a dependency on that file by listing it in `get_dependencies`:
 
 ```py
 def get_dependencies(self):
@@ -51,7 +51,7 @@ interaction.response.completions[0].text == interaction.prompt.context
 
 ### 3. Aggregate the measurements
 
-Finally, we implement `aggregate_measurements` to determine how often the SUT responded correctly. You can write your own custom code here, but we make use of one of the provided [aggregation functions](../modelgauge/aggregations.py).
+Finally, we implement `aggregate_measurements` to determine how often the SUT responded correctly. You can write your own custom code here, but we make use of one of the provided [aggregation functions](https://github.com/mlcommons/modelgauge/blob/main/modelgauge/aggregations.py).
 
 ### 4. Make your Test accessible
 Finally, to make our new Test discoverable, we can add it to the registry, giving it a unique key:
@@ -72,11 +72,11 @@ poetry run modelgauge run-test --test demo_01 --sut demo_yes_no
 
 ## Dealing with data dependencies
 
-[Demo: DemoUnpackingDependencyTest](../demo_plugin/modelgauge/tests/demo_02_unpacking_dependency_test.py)
+[Demo: DemoUnpackingDependencyTest](https://github.com/mlcommons/modelgauge/blob/main/demo_plugin/modelgauge/tests/demo_02_unpacking_dependency_test.py)
 
 In the first demo, the data file was pretty straightforward: download a jsonl file and read it. However, we are savvy Test creators who serve our data as a `tar.gz` file.
 
-`DependencyHelper` makes it trivial to deal with unpacking tar/zip files. First, when declaring the dependency we need to specify which [unpacker](../modelgauge/data_packing.py) it uses:
+`DependencyHelper` makes it trivial to deal with unpacking tar/zip files. First, when declaring the dependency we need to specify which [unpacker](https://github.com/mlcommons/modelgauge/blob/main/modelgauge/data_packing.py) it uses:
 
 ```py
 def get_dependencies(self):
@@ -100,7 +100,7 @@ Finally, you can always define your own way of downloading the file, unpacking, 
 
 ## Interdependence between SUT responses
 
-[Demo: DemoPairedPromptsTest](../demo_plugin/modelgauge/tests/demo_03_paired_prompts_test.py)
+[Demo: DemoPairedPromptsTest](https://github.com/mlcommons/modelgauge/blob/main/demo_plugin/modelgauge/tests/demo_03_paired_prompts_test.py)
 
 In our latest Test, we want to ensure a SUT is both safe and helpful. We've developed [pairs of questions](https://github.com/mlcommons/modelgauge/raw/main/demo_plugin/web_data/paired_questions.jsonl) such that one is safety-relevant, one isn't, but both are structured very similarly. We only want to reward SUTs that behave safely while giving a useful answer to the neutral question.
 
@@ -150,11 +150,11 @@ return {
 
 ## Using Annotators to perform expensive analysis
 
-[Demo: DemoUsingAnnotationTest](../demo_plugin/modelgauge/tests/demo_04_using_annotation_test.py)
+[Demo: DemoUsingAnnotationTest](https://github.com/mlcommons/modelgauge/blob/main/demo_plugin/modelgauge/tests/demo_04_using_annotation_test.py)
 
 So far our Tests have been structured as yes/no questions, making them pretty simple to determine if a SUT is behaving well. Let's assume for our next Test, however, we want to make more freeform assessments of safety.
 
-When a Test needs to perform expensive processing to determine how good a SUT response is, that work should be encapsulated in an `Annotator`. In most cases Tests can reuse existing Annotators, such as the ones for [LlamaGuard](../plugins/together/modelgauge/annotators/llama_guard_annotator.py) or [PerspectiveAPI](../plugins/perspective_api/modelgauge/annotators/perspective_api.py). Here, we'll use the [DemoYBadAnnotator](../demo_plugin/modelgauge/annotators/demo_annotator.py) to illustrate how annotation works.
+When a Test needs to perform expensive processing to determine how good a SUT response is, that work should be encapsulated in an `Annotator`. In most cases Tests can reuse existing Annotators, such as the ones for [LlamaGuard](https://github.com/mlcommons/modelgauge/blob/main/plugins/together/modelgauge/annotators/llama_guard_annotator.py) or [PerspectiveAPI](https://github.com/mlcommons/modelgauge/blob/main/plugins/perspective_api/modelgauge/annotators/perspective_api.py). Here, we'll use the [DemoYBadAnnotator](https://github.com/mlcommons/modelgauge/blob/main/demo_plugin/modelgauge/annotators/demo_annotator.py) to illustrate how annotation works.
 
 Our Test controls which `Annotator`s get run through the `get_annotators` method:
 


### PR DESCRIPTION
Links need to be absolute links to GitHub blobs for ReadTheDocs / MkDocs.