### PR TITLE
Remove poetry run from the SUTs and tests tutorial

### DIFF
--- a/docs/tutorial_suts.md
+++ b/docs/tutorial_suts.md
@@ -100,13 +100,13 @@ ModelGauge's [plugin architecture](plugins.md) will automatically try to import 
 With our SUT installed (either via plugin or in the local directory), we can run it manually with `run-sut`:
 
 ```
-poetry run modelgauge run-sut --sut demo_yes_no --prompt "One two three four"
+modelgauge run-sut --sut demo_yes_no --prompt "One two three four"
 ```
 
 We can also evaluate it using any Test in ModelGauge!
 
 ```
-poetry run modelgauge run-test --test demo_01 --sut demo_yes_no
+modelgauge run-test --test demo_01 --sut demo_yes_no
 ```
 
 ## SUTs that call an API

--- a/docs/tutorial_tests.md
+++ b/docs/tutorial_tests.md
@@ -67,7 +67,7 @@ ModelGauge's [plugin architecture](plugins.md) will automatically try to import 
 With our Test installed (either via plugin or in the local directory), we can run it against any SUT in ModelGauge!
 
 ```
-poetry run modelgauge run-test --test demo_01 --sut demo_yes_no
+modelgauge run-test --test demo_01 --sut demo_yes_no
 ```
 
 ## Dealing with data dependencies


### PR DESCRIPTION
These tutorials do not need poetry installed, so I've removed `poetry run` from them.