### PR TITLE
Allow local plugin loading

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -21,6 +21,17 @@ If you would like to create a plugin that is distributed as part of the ModelGau
 
 TODO: Write the guidance for adding a plugin requiring a dependency.
 
+## From a local directory
+It is possible to load plugins from a local directory for certain commands using the CLI option `--plugin-dir`. For example:
+
+```shell
+modelgauge run-sut --sut mycoolplugin --plugin-dir /my/plugins --prompt "Can you answer this question?"
+```
+
+> [!WARNING]
+> `--plugin-dir` will import any modules in the specified directory which can execute code that could be harmful, malicious, 
+> or that could have unexpected consequences. Use with caution and in a trusted environment.
+
 ## In your own package
 
 ModelGauge also supports distributing your plugin in its own package. Lets assume you want to call it `mycoolplugin`. Using this guide, if someone wanted to use your plugins, they could do so with the following commands:

--- a/modelgauge/command_line.py
+++ b/modelgauge/command_line.py
@@ -1,3 +1,7 @@
+import pathlib
+import pkgutil
+import sys
+
 import click
 from modelgauge.config import write_default_config
 
@@ -19,6 +23,14 @@ def display_list_item(text):
     click.echo(f"\t{text}")
 
 
+def load_local_plugins(_, __, path: pathlib.Path):
+    path_str = str(path)
+    sys.path.append(path_str)
+    plugins = pkgutil.walk_packages([path_str])
+    for plugin in plugins:
+        __import__(plugin.name)
+
+
 # Define some reusable options
 DATA_DIR_OPTION = click.option(
     "--data-dir",
@@ -35,3 +47,13 @@ MAX_TEST_ITEMS_OPTION = click.option(
 )
 
 SUT_OPTION = click.option("--sut", help="Which registered SUT to run.", required=True)
+
+LOCAL_PLUGIN_DIR_OPTION = click.option(
+    "--plugin-dir",
+    type=click.Path(
+        exists=True, dir_okay=True, path_type=pathlib.Path, file_okay=False
+    ),
+    help="Directory containing plugins to load",
+    callback=load_local_plugins,
+    expose_value=False,
+)

--- a/modelgauge/main.py
+++ b/modelgauge/main.py
@@ -3,6 +3,7 @@ import click
 from modelgauge.base_test import PromptResponseTest
 from modelgauge.command_line import (
     DATA_DIR_OPTION,
+    LOCAL_PLUGIN_DIR_OPTION,
     MAX_TEST_ITEMS_OPTION,
     SUT_OPTION,
     display_header,
@@ -19,7 +20,6 @@ from modelgauge.general import normalize_filename
 from modelgauge.instance_factory import FactoryEntry
 from modelgauge.load_plugins import list_plugins, load_plugins
 from modelgauge.prompt import SUTOptions, TextPrompt
-from modelgauge.simple_test_runner import run_prompt_response_test
 from modelgauge.secret_values import MissingSecretValues, RawSecrets, get_all_secrets
 from modelgauge.sut import PromptResponseSUT
 from modelgauge.sut_registry import SUTS
@@ -28,6 +28,7 @@ from typing import List, Optional
 
 
 @modelgauge_cli.command(name="list")
+@LOCAL_PLUGIN_DIR_OPTION
 def list_command() -> None:
     """Overview of Plugins, Tests, and SUTs."""
     plugins = list_plugins()
@@ -74,6 +75,7 @@ def _display_factory_entry(uid: str, entry: FactoryEntry, secrets: RawSecrets):
 
 
 @modelgauge_cli.command()
+@LOCAL_PLUGIN_DIR_OPTION
 def list_tests() -> None:
     """List details about all registered tests."""
     secrets = load_secrets_from_config()
@@ -82,6 +84,7 @@ def list_tests() -> None:
 
 
 @modelgauge_cli.command()
+@LOCAL_PLUGIN_DIR_OPTION
 def list_suts():
     """List details about all registered SUTs (System Under Test)."""
     secrets = load_secrets_from_config()
@@ -90,6 +93,7 @@ def list_suts():
 
 
 @modelgauge_cli.command()
+@LOCAL_PLUGIN_DIR_OPTION
 def list_secrets() -> None:
     """List details about secrets modelgauge might need."""
     descriptions = get_all_secrets()
@@ -101,6 +105,7 @@ def list_secrets() -> None:
 
 
 @modelgauge_cli.command()
+@LOCAL_PLUGIN_DIR_OPTION
 @SUT_OPTION
 @click.option("--prompt", help="The full text to send to the SUT.")
 @click.option(
@@ -155,6 +160,7 @@ def run_sut(
 
 @modelgauge_cli.command()
 @click.option("--test", help="Which registered TEST to run.", required=True)
+@LOCAL_PLUGIN_DIR_OPTION
 @SUT_OPTION
 @DATA_DIR_OPTION
 @MAX_TEST_ITEMS_OPTION

--- a/modelgauge/main.py
+++ b/modelgauge/main.py
@@ -20,6 +20,7 @@ from modelgauge.general import normalize_filename
 from modelgauge.instance_factory import FactoryEntry
 from modelgauge.load_plugins import list_plugins, load_plugins
 from modelgauge.prompt import SUTOptions, TextPrompt
+from modelgauge.simple_test_runner import run_prompt_response_test
 from modelgauge.secret_values import MissingSecretValues, RawSecrets, get_all_secrets
 from modelgauge.sut import PromptResponseSUT
 from modelgauge.sut_registry import SUTS


### PR DESCRIPTION
This adds a CLI option that allows the user to designate a local directory that can contain plugins to be loaded at runtime.