### PR TITLE
Add LogProbs capability to HuggingFaceSUT

### DIFF
--- a/plugins/huggingface/modelgauge/suts/huggingface_client.py
+++ b/plugins/huggingface/modelgauge/suts/huggingface_client.py
@@ -148,8 +148,6 @@ class HuggingFaceToken(OptionalSecret):
     ]
 )
 class HuggingFaceSUT(PromptResponseSUT[HuggingFaceRequest, HuggingFaceResponse]):
-    """A thin wrapper around a Hugging Face AutoModelForCausalLM for HuggingFaceClient to call."""
-
     def __init__(
         self,
         uid: str,

--- a/plugins/huggingface/tests/fake_model.py
+++ b/plugins/huggingface/tests/fake_model.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 from typing import List, Union
 
 import torch
-from transformers.tokenization_utils_base import BatchEncoding
+from transformers import BatchEncoding  # type: ignore
 
 from modelgauge.suts.huggingface_client import (
     HuggingFaceSUT,
@@ -46,27 +46,19 @@ class MockTokenizer:
             token_ids.append(sequence_ids)
             mask.append([1] * len(sequence_ids))
 
-        if kwargs.get("return_tensors") == "pt":
-            token_ids = torch.tensor(token_ids)
-            mask = torch.tensor(mask)
         encoding_data = {"input_ids": token_ids}
         if self.returns_mask:
             encoding_data["attention_mask"] = mask
 
-        return BatchEncoding(encoding_data)
+        return BatchEncoding(encoding_data, tensor_type=kwargs.get("return_tensors"))
 
-    def decode(self, token_ids: Union[int, List[int], torch.Tensor]) -> str:
+    def decode(self, token_ids: Union[int, List[int], "torch.Tensor"]) -> str:
         if torch.is_tensor(token_ids):
-            token_ids = token_ids.tolist()
-        decoded_tokens = self.convert_ids_to_tokens(token_ids)
+            token_ids = token_ids.tolist()  # type: ignore
+        decoded_tokens = self.convert_ids_to_tokens(token_ids)  # type: ignore
         if isinstance(decoded_tokens, list):
             return " ".join(decoded_tokens)
         return decoded_tokens
-
-    def batch_decode(
-        self, sequences: Union[List[int], List[List[int]], torch.Tensor]
-    ) -> List[str]:
-        return [self.decode(sequence) for sequence in sequences]
 
     def convert_ids_to_tokens(
         self, ids: Union[int, List[int]]

--- a/plugins/huggingface/tests/fake_model.py
+++ b/plugins/huggingface/tests/fake_model.py
@@ -1,0 +1,76 @@
+from unittest.mock import MagicMock
+from typing import List, Union
+
+import torch
+from transformers.tokenization_utils_base import BatchEncoding
+
+from modelgauge.suts.huggingface_client import (
+    HuggingFaceSUT,
+    HuggingFaceToken,
+    WrappedPreTrainedTokenizer,
+)
+
+
+def make_client():
+    return HuggingFaceSUT(
+        uid="test-sut",
+        pretrained_model_name_or_path="some-model",
+        token=HuggingFaceToken("some-value"),
+    )
+
+
+def make_mocked_client(vocab_map, **t_kwargs):
+    mock_model = MagicMock()
+    client = make_client()
+    client.wrapped_tokenizer = WrappedPreTrainedTokenizer(
+        MockTokenizer(vocab_map, **t_kwargs)
+    )
+    client.model = mock_model
+    return client
+
+
+class MockTokenizer:
+    def __init__(self, vocab_map, model_max_length=512, return_mask=False):
+        self.model_max_length = model_max_length
+        self.returns_mask = return_mask
+        self.vocab = vocab_map
+        self.id_to_token = {id: token for token, id in self.vocab.items()}
+
+    def __call__(self, text: Union[str, List[str]], **kwargs) -> BatchEncoding:
+        if isinstance(text, str):
+            text = [text]
+        token_ids = []
+        mask = []
+        for sequence in text:
+            sequence_ids = [self.vocab.get(token, 0) for token in sequence.split()]
+            token_ids.append(sequence_ids)
+            mask.append([1] * len(sequence_ids))
+
+        if kwargs.get("return_tensors") == "pt":
+            token_ids = torch.tensor(token_ids)
+            mask = torch.tensor(mask)
+        encoding_data = {"input_ids": token_ids}
+        if self.returns_mask:
+            encoding_data["attention_mask"] = mask
+
+        return BatchEncoding(encoding_data)
+
+    def decode(self, token_ids: Union[int, List[int], torch.Tensor]) -> str:
+        if torch.is_tensor(token_ids):
+            token_ids = token_ids.tolist()
+        decoded_tokens = self.convert_ids_to_tokens(token_ids)
+        if isinstance(decoded_tokens, list):
+            return " ".join(decoded_tokens)
+        return decoded_tokens
+
+    def batch_decode(
+        self, sequences: Union[List[int], List[List[int]], torch.Tensor]
+    ) -> List[str]:
+        return [self.decode(sequence) for sequence in sequences]
+
+    def convert_ids_to_tokens(
+        self, ids: Union[int, List[int]]
+    ) -> Union[str, List[str]]:
+        if isinstance(ids, int):
+            return self.id_to_token[ids]
+        return [self.id_to_token[id] for id in ids]

--- a/plugins/huggingface/tests/test_huggingface_client.py
+++ b/plugins/huggingface/tests/test_huggingface_client.py
@@ -1,11 +1,9 @@
-from torch import Tensor, tensor, is_tensor, equal
-from transformers.generation.stopping_criteria import StoppingCriteriaList
-from transformers import PreTrainedTokenizerBase
-from transformers.tokenization_utils_base import BatchEncoding
-from typing import List, Union
-from unittest.mock import Mock, patch, MagicMock
 import pytest
-from modelgauge.caching import SqlDictCache
+import torch
+from transformers.generation.stopping_criteria import StoppingCriteriaList
+from transformers.utils import ModelOutput
+
+from fake_model import make_client, make_mocked_client
 from modelgauge.prompt import SUTOptions, ChatMessage, ChatPrompt, ChatRole, TextPrompt
 from modelgauge.prompt_formatting import format_chat
 from modelgauge.sut import SUTCompletion, SUTResponse, TokenProbability, TopTokens
@@ -13,115 +11,63 @@ from modelgauge.suts.huggingface_client import (
     HuggingFaceCompletion,
     HuggingFaceRequest,
     HuggingFaceResponse,
-    HuggingFaceSUT,
-    HuggingFaceToken,
-    StopAtSpecificTokenCriteria,
-    WrappedPreTrainedTokenizer,
 )
 
 _DEFAULT_REQUEST_ARGS = {
     "model": "some-model",
-    "top_k_per_token": 1,
     "generate_args": {
         "temperature": 1.0,
         "num_return_sequences": 1,
         "top_p": 1.0,
+        "top_k": 1,
     },
 }
 
-_INPUT_LIST = [[1, 2, 3, 4, 5]]
-# _INPUT_TENSOR = tensor(_INPUT_LIST)
-_INPUT_TENSOR = tensor([[1, 2]])
 
-_MASK_LIST = [[1, 1, 1, 0, 0]]
-_MASK_TENSOR = tensor(_MASK_LIST)
-_STOP_SEQUENCES_IDS = [[4], [5, 6]]
-
+_UNK_TOKEN_ID = 0
 _VOCAB_MAP = {
-    "<unk>": 0,
-    "hello": 1,
-    "world": 2,
-    "<stop>": 3,
+    "<unk>": _UNK_TOKEN_ID,
+    "one": 1,
+    "two": 2,
+    "three": 3,
 }
 
 
-def _make_client():
-    return HuggingFaceSUT(
-        uid="test-sut",
-        pretrained_model_name_or_path="some-model",
-        token=HuggingFaceToken("some-value"),
+def _make_request(
+    text="some text prompt", max_new_tokens=100, stop_sequences=[], **kwargs
+):
+    return HuggingFaceRequest(
+        prompt=text,
+        max_new_tokens=max_new_tokens,
+        stop_sequences=stop_sequences,
+        **_DEFAULT_REQUEST_ARGS,
+        **kwargs,
     )
 
 
-def _make_mocked_client(**kwargs):
-    mock_model = MagicMock()
-    client = _make_client()
-    client.wrapped_tokenizer = WrappedPreTrainedTokenizer(MockTokenizer(**kwargs))
-    client.model = mock_model
-    return client
+def _make_generate_output(output_ids, num_input_ids, output_scores=None):
+    """Used to patch return model.generate() return value."""
 
-
-class MockTokenizer:
-    def __init__(self, model_max_length=512, return_mask=False):
-        self.model_max_length = model_max_length
-        self.return_mask = return_mask
-        self.vocab = _VOCAB_MAP
-        self.id_to_token = {id: token for token, id in self.vocab.items()}
-
-    def __call__(self, text: Union[str, List[str]], **kwargs) -> BatchEncoding:
-        if isinstance(text, str):
-            text = [text]
-        token_ids = []
-        mask = []
-        for sequence in text:
-            sequence_ids = [self.vocab.get(token, 0) for token in sequence.split()]
-            token_ids.append(sequence_ids)
-            mask.append([1] * len(sequence_ids))
-
-        if kwargs.get("return_tensors") == "pt":
-            token_ids = tensor(token_ids)
-            mask = tensor(mask)
-        encoding_data = {"input_ids": token_ids}
-        if self.return_mask:
-            encoding_data["attention_mask"] = mask
-
-        return BatchEncoding(encoding_data)
-
-    def decode(self, token_ids: Union[int, List[int], "torch.Tensor"]) -> str:
-        if is_tensor(token_ids):
-            token_ids = token_ids.tolist()
-        decoded_tokens = self.convert_ids_to_tokens(token_ids)
-        if isinstance(decoded_tokens, list):
-            return " ".join(decoded_tokens)
-        return decoded_tokens
-
-    def batch_decode(
-        self, sequences: Union[List[int], List[List[int]], "torch.Tensor"]
-    ) -> List[str]:
-        return [self.decode(sequence) for sequence in sequences]
-
-    def convert_ids_to_tokens(
-        self, ids: Union[int, List[int]]
-    ) -> Union[str, List[str]]:
-        if isinstance(ids, int):
-            return self.id_to_token[ids]
-        return [self.id_to_token[id] for id in ids]
+    dummy_input_ids = torch.zeros(
+        (output_ids.size(0), num_input_ids), dtype=output_ids.dtype
+    )
+    # Prepend input-ids in output sequence
+    output_data = {"sequences": torch.cat((dummy_input_ids, output_ids), dim=1)}
+    if output_scores:
+        output_data["scores"] = output_scores
+    return ModelOutput(output_data)
 
 
 def test_huggingface_translate_text_prompt_request():
-    client = _make_client()
+    client = make_client()
     prompt = TextPrompt(text="some text prompt")
     request = client.translate_text_prompt(prompt)
-    assert request == HuggingFaceRequest(
-        prompt="some text prompt",
-        max_new_tokens=100,
-        stop_sequences=[],
-        **_DEFAULT_REQUEST_ARGS
-    )
+    assert request == _make_request(text="some text prompt")
+    assert request.num_top_logprobs is None
 
 
 def test_huggingface_translate_chat_prompt_request():
-    client = _make_client()
+    client = make_client()
     prompt = ChatPrompt(
         messages=[
             ChatMessage(text="some-text", role=ChatRole.user),
@@ -133,7 +79,7 @@ def test_huggingface_translate_chat_prompt_request():
 
 
 def test_huggingface_translate_request_non_default_options():
-    client = _make_client()
+    client = make_client()
     options = SUTOptions(
         temperature=0.5,
         num_completions=2,
@@ -141,115 +87,210 @@ def test_huggingface_translate_request_non_default_options():
         max_tokens=15,
         top_k_per_token=3,
         stop_sequences=["stop"],
+        top_logprobs=40,
     )
     request = client._translate_request("some text prompt", options)
-    assert request == HuggingFaceRequest(
-        prompt="some text prompt",
-        model="some-model",
-        max_new_tokens=15,
-        top_k_per_token=3,
-        stop_sequences=["stop"],
-        generate_args={"temperature": 0.5, "num_return_sequences": 2, "top_p": 0.4},
-    )
+    assert request.max_new_tokens == 15
+    assert request.stop_sequences == ["stop"]
+    assert request.generate_args.model_dump() == {
+        "temperature": 0.5,
+        "num_return_sequences": 2,
+        "top_p": 0.4,
+        "top_k": 3,
+    }
+    assert request.num_top_logprobs == 40
+
     # Test that temperature of 0 is adjusted.
     request = client._translate_request("some text prompt", SUTOptions(temperature=0.0))
     assert request.generate_args.temperature == 1e-7
 
 
-def test_huggingface_request_serialization_cacheable(tmpdir):
-    request = HuggingFaceRequest(
-        prompt="prompt", max_new_tokens=100, stop_sequences=[], **_DEFAULT_REQUEST_ARGS
-    )
-    with SqlDictCache(tmpdir, "sut_name") as cache:
-        cache._hash_request(request)
-
-
 def test_huggingface_generate_args():
     """Tests that the expected arguments are passed to the .generate() call in the evaluate method."""
-    client = _make_mocked_client()
-    request = HuggingFaceRequest(
-        prompt="hello world",
-        max_new_tokens=100,
-        stop_sequences=[],
-        **_DEFAULT_REQUEST_ARGS
-    )
+    client = make_mocked_client(_VOCAB_MAP)
+    request = _make_request(text="one two unknown", max_new_tokens=100)
     client.evaluate(request)
 
     _, generate_call_kwargs = client.model.generate.call_args
+    # Need to check tensor equality separately
     input_ids = generate_call_kwargs.pop("input_ids")
-    assert is_tensor(input_ids)
-    assert equal(input_ids, _INPUT_TENSOR)
+    assert torch.is_tensor(input_ids)
+    assert torch.equal(input_ids, torch.tensor([[1, 2, _UNK_TOKEN_ID]]))
     assert generate_call_kwargs == {
         **_DEFAULT_REQUEST_ARGS["generate_args"],
         "max_new_tokens": 100,
         "do_sample": True,
         "return_dict_in_generate": True,
-        "output_scores": True,
+        "output_scores": False,
     }
 
 
+@pytest.mark.parametrize(
+    "num_top_logprobs,output_scores", [(50, True), (1, True), (0, False), (None, False)]
+)
+def test_huggingface_generate_args_logprobs(num_top_logprobs, output_scores):
+    client = make_mocked_client(_VOCAB_MAP)
+    request = _make_request(num_top_logprobs=num_top_logprobs)
+    client.evaluate(request)
+
+    _, generate_call_kwargs = client.model.generate.call_args
+    assert generate_call_kwargs["output_scores"] == output_scores
+
+
 def test_huggingface_generate_args_mask():
-    """Tests that the expected arguments are passed to the .generate() call in the evaluate method."""
-    client = _make_mocked_client(return_mask=True)
-    request = HuggingFaceRequest(
-        prompt="hello world",
-        max_new_tokens=100,
-        stop_sequences=[],
-        **_DEFAULT_REQUEST_ARGS
-    )
+    """Tests that the attention mask is passed to the .generate() call if tokenizer outputs a mask."""
+    client = make_mocked_client(_VOCAB_MAP, return_mask=True)
+    request = _make_request(text="one two")
     client.evaluate(request)
 
     _, generate_call_kwargs = client.model.generate.call_args
     mask = generate_call_kwargs.get("attention_mask")
-    assert is_tensor(mask)
-    assert equal(mask, tensor([[1, 1]]))
+    assert torch.is_tensor(mask)
+    assert torch.equal(mask, torch.tensor([[1, 1]]))
 
 
 def test_huggingface_generate_stopping_criteria_arg():
-    client = _make_mocked_client()
-    request = HuggingFaceRequest(
-        prompt="hello world",
-        max_new_tokens=100,
-        stop_sequences=["<stop>", "hello <eos>"],
-        **_DEFAULT_REQUEST_ARGS
-    )
+    client = make_mocked_client(_VOCAB_MAP)
+    request = _make_request(stop_sequences=["two", "three word stop"])
     client.evaluate(request)
 
     _, generate_call_kwargs = client.model.generate.call_args
     stopping_criteria = generate_call_kwargs["stopping_criteria"]
     assert isinstance(stopping_criteria, StoppingCriteriaList)
-    assert [token.stop_sequence for token in stopping_criteria] == [
-        [_VOCAB_MAP["<stop>"]],
-        [_VOCAB_MAP["hello"], _VOCAB_MAP["<unk>"]],
-    ]
+    stopping_criteria_ids = [[2], [3, _UNK_TOKEN_ID, _UNK_TOKEN_ID]]
+    assert [token.stop_sequence for token in stopping_criteria] == stopping_criteria_ids
 
 
 def test_huggingface_generate_args_with_reduced_max_tokens():
     """If total num. tokens (max_tokens + prompt length) exceeds model's max length, the max_new_tokens is adjusted."""
-    client = _make_mocked_client(model_max_length=53)
-
-    request = HuggingFaceRequest(
-        prompt="some text prompt",
-        max_new_tokens=75,
-        stop_sequences=[],
-        **_DEFAULT_REQUEST_ARGS
-    )
+    client = make_mocked_client(_VOCAB_MAP, model_max_length=52)
+    request = _make_request(text="some prompt")
     client.evaluate(request)
+
     _, generate_call_kwargs = client.model.generate.call_args
     assert generate_call_kwargs["max_new_tokens"] == 50
 
 
-def test_huggingface_evaluate_prompt_too_large_exception():
+@pytest.mark.parametrize("model_max_length", [2, 3, 0])
+def test_huggingface_evaluate_prompt_too_large_exception(model_max_length):
     """Exception is raised if the num. of prompt tokens exceeds the the model's max length."""
-    client = _make_mocked_client(model_max_length=3)
-
-    request = HuggingFaceRequest(
-        prompt="some text prompt",
-        max_new_tokens=75,
-        stop_sequences=[],
-        **_DEFAULT_REQUEST_ARGS
-    )
+    client = make_mocked_client(_VOCAB_MAP, model_max_length=model_max_length)
+    request = _make_request(text="three token prompt")
     with pytest.raises(
-        AssertionError, match="Prompt has 3 tokens, which is >= max length 3"
+        AssertionError,
+        match=f"Prompt has 3 tokens, which is >= max length {model_max_length}",
     ):
         client.evaluate(request)
+
+
+def test_huggingface_evaluate():
+    client = make_mocked_client(_VOCAB_MAP)
+    client.model.generate.return_value = _make_generate_output(
+        torch.tensor([[3, 2, 1]]), num_input_ids=1
+    )
+
+    request = _make_request(text="input")
+    response = client.evaluate(request)
+    assert response == HuggingFaceResponse(
+        completions=[HuggingFaceCompletion(text="three two one")]
+    )
+
+
+def test_huggingface_evaluate_multiple_completions():
+    client = make_mocked_client(_VOCAB_MAP)
+    client.model.generate.return_value = _make_generate_output(
+        torch.tensor([[1, 2], [2, 1], [2, 2]]), num_input_ids=1
+    )
+
+    request = client._translate_request("input", SUTOptions(num_completions=3))
+    response = client.evaluate(request)
+    assert response == HuggingFaceResponse(
+        completions=[
+            HuggingFaceCompletion(text="one two"),
+            HuggingFaceCompletion(text="two one"),
+            HuggingFaceCompletion(text="two two"),
+        ]
+    )
+
+
+def test_huggingface_evaluate_response_with_logprobs():
+    num_logprobs = 3
+    client = make_mocked_client(_VOCAB_MAP)
+    output_token_ids = torch.tensor([[1, 2]])
+    random_scores = (torch.rand(1, 4), torch.rand(1, 4))
+    client.model.generate.return_value = _make_generate_output(
+        output_token_ids, num_input_ids=1, output_scores=random_scores
+    )
+    request = client._translate_request("input", SUTOptions(top_logprobs=num_logprobs))
+    response = client.evaluate(request)
+    assert len(response.completions) == 1
+    assert response.completions[0].text == "one two"
+    logprob_dicts = response.completions[0].top_logprobs_dicts
+    # One logprob dict for each token in the output sequence
+    assert len(logprob_dicts) == 2
+    for logprobs in logprob_dicts:
+        assert isinstance(logprobs, dict)
+        assert len(logprobs) == num_logprobs
+        assert all(isinstance(token, str) for token in logprobs.keys())
+        assert all(isinstance(logprob, float) for logprob in logprobs.values())
+
+
+@pytest.mark.parametrize(
+    "max_new_tokens,expected_text", [(2, "three two"), (1, "three")]
+)
+def test_huggingface_evaluate_truncate(max_new_tokens, expected_text):
+    """Output sequence is truncated if model does not comply with max_new_tokens."""
+    client = make_mocked_client(_VOCAB_MAP)
+    client.model.generate.return_value = _make_generate_output(
+        torch.tensor([[3, 2, 1]]), num_input_ids=1
+    )
+
+    request = _make_request(text="input", max_new_tokens=max_new_tokens)
+    response = client.evaluate(request)
+    assert response.completions == [HuggingFaceCompletion(text=expected_text)]
+
+
+def test_huggingface_translate_response():
+    client = make_client()
+    request = _make_request(text="input")
+    response = HuggingFaceResponse(completions=[HuggingFaceCompletion(text="output")])
+
+    sut_response = client.translate_response(request, response)
+    assert sut_response == SUTResponse(completions=[SUTCompletion(text="output")])
+
+
+def test_huggingface_translate_response_logprobs():
+    client = make_client()
+    request = client._translate_request("input", SUTOptions(top_logprobs=3))
+    response = HuggingFaceResponse(
+        completions=[
+            HuggingFaceCompletion(
+                text="output",
+                top_logprobs_dicts=[
+                    {"token1": 0.1, "token2": 0.2, "token3": 0.3},
+                    {"token2": -0.4, "token3": 0.5, "token4": 0.6},
+                ],
+            )
+        ]
+    )
+    logprobs = [
+        TopTokens(
+            top_tokens=[
+                TokenProbability(token="token1", logprob=0.1),
+                TokenProbability(token="token2", logprob=0.2),
+                TokenProbability(token="token3", logprob=0.3),
+            ]
+        ),
+        TopTokens(
+            top_tokens=[
+                TokenProbability(token="token2", logprob=-0.4),
+                TokenProbability(token="token3", logprob=0.5),
+                TokenProbability(token="token4", logprob=0.6),
+            ]
+        ),
+    ]
+
+    sut_response = client.translate_response(request, response)
+    assert sut_response == SUTResponse(
+        completions=[SUTCompletion(text="output", top_logprobs=logprobs)]
+    )

--- a/plugins/huggingface/tests/test_huggingface_client.py
+++ b/plugins/huggingface/tests/test_huggingface_client.py
@@ -1,9 +1,9 @@
 import pytest
 import torch
-from transformers.generation.stopping_criteria import StoppingCriteriaList
-from transformers.utils import ModelOutput
+from transformers.generation.stopping_criteria import StoppingCriteriaList  # type: ignore
+from transformers.utils import ModelOutput  # type: ignore
 
-from fake_model import make_client, make_mocked_client
+from fake_model import make_client, make_mocked_client  # type: ignore
 from modelgauge.prompt import SUTOptions, ChatMessage, ChatPrompt, ChatRole, TextPrompt
 from modelgauge.prompt_formatting import format_chat
 from modelgauge.sut import SUTCompletion, SUTResponse, TokenProbability, TopTokens

--- a/plugins/huggingface/tests/test_huggingface_client.py
+++ b/plugins/huggingface/tests/test_huggingface_client.py
@@ -1,0 +1,126 @@
+from torch import tensor
+from transformers import PreTrainedTokenizerBase
+from transformers.tokenization_utils_base import BatchEncoding
+from typing import List
+from unittest.mock import Mock, patch, MagicMock
+import pytest
+from modelgauge.prompt import SUTOptions, ChatMessage, ChatPrompt, ChatRole, TextPrompt
+from modelgauge.prompt_formatting import format_chat
+from modelgauge.sut import SUTCompletion, SUTResponse, TokenProbability, TopTokens
+from modelgauge.suts.huggingface_client import (
+    HuggingFaceCompletion,
+    HuggingFaceRequest,
+    HuggingFaceResponse,
+    HuggingFaceSUT,
+    HuggingFaceToken,
+    WrappedPreTrainedTokenizer,
+)
+
+_DEFAULT_REQUEST_ARGS = {
+    "temperature": 1.0,
+    "top_p": 1,
+    "top_k_per_token": 1,
+}
+
+
+def _make_client():
+    return HuggingFaceSUT(
+        uid="test-sut",
+        pretrained_model_name_or_path="some-model",
+        token=HuggingFaceToken("some-value"),
+    )
+
+
+class MockTokenizer:
+    def __init__(self, output_id_sequences: List[List[int]], model_max_length=512):
+        self.model_max_length = model_max_length
+        outputs = []
+        for ids in output_id_sequences:
+            outputs.append(BatchEncoding({"input_ids": ids}))
+        self.output_stack = list(reversed(outputs))
+        self.text_inputs_receieved = []
+
+    def __call__(self, *args, **kwargs) -> BatchEncoding:
+        self.text_inputs_receieved.append(args[0])
+        return self.output_stack.pop()
+
+
+def test_huggingface_translate_text_prompt_request(mocker):
+    def mock_create_tokenizer(*args, **kwargs):
+        return WrappedPreTrainedTokenizer(MockTokenizer([[1, 2, 3]]))
+
+    mocker.patch(
+        "modelgauge.suts.huggingface_client.create_tokenizer", new=mock_create_tokenizer
+    )
+    client = _make_client()
+    prompt = TextPrompt(text="some text prompt")
+    request = client.translate_text_prompt(prompt)
+    assert request == HuggingFaceRequest(
+        input_ids=[1, 2, 3],
+        model="some-model",
+        num_return_sequences=1,
+        max_new_tokens=100,
+        **_DEFAULT_REQUEST_ARGS
+    )
+
+
+def test_huggingface_translate_chat_prompt_request(mocker):
+    mock_tokenizer = MockTokenizer([[1, 2, 3]])
+
+    def mock_create_tokenizer(*args, **kwargs):
+        return WrappedPreTrainedTokenizer(mock_tokenizer)
+
+    mocker.patch(
+        "modelgauge.suts.huggingface_client.create_tokenizer", new=mock_create_tokenizer
+    )
+    client = _make_client()
+    prompt = ChatPrompt(
+        messages=[
+            ChatMessage(text="some-text", role=ChatRole.user),
+            ChatMessage(text="more-text", role=ChatRole.sut),
+        ]
+    )
+    request = client.translate_chat_prompt(prompt)
+    assert mock_tokenizer.text_inputs_receieved == [format_chat(prompt)]
+
+
+def test_huggingface_translate_request_reduce_max_tokens(mocker):
+    """If total num. tokens (max_tokens + prompt length) exceeds model's max length, the max_new_tokens is adjusted."""
+
+    def mock_create_tokenizer(*args, **kwargs):
+        return WrappedPreTrainedTokenizer(
+            MockTokenizer([[1, 2, 3, 4, 5]], model_max_length=55)
+        )
+
+    mocker.patch(
+        "modelgauge.suts.huggingface_client.create_tokenizer", new=mock_create_tokenizer
+    )
+    client = _make_client()
+    prompt = TextPrompt(text="prompt", options=SUTOptions(max_tokens=75))
+    request = client.translate_text_prompt(prompt)
+    assert request == HuggingFaceRequest(
+        input_ids=[1, 2, 3, 4, 5],
+        model="some-model",
+        num_return_sequences=1,
+        max_new_tokens=50,
+        **_DEFAULT_REQUEST_ARGS
+    )
+
+
+def test_huggingface_translate_request_prompt_too_large_exception(
+    mocker,
+):
+    """Exception is raised if the num. of prompt tokens exceeds the the model's max length."""
+
+    def mock_create_tokenizer(*args, **kwargs):
+        return WrappedPreTrainedTokenizer(
+            MockTokenizer([[1, 2, 3]], model_max_length=3)
+        )
+
+    mocker.patch(
+        "modelgauge.suts.huggingface_client.create_tokenizer", new=mock_create_tokenizer
+    )
+    client = _make_client()
+    prompt = TextPrompt(text="prompt")
+    with pytest.raises(AssertionError):
+        client.translate_text_prompt(prompt)


### PR DESCRIPTION
This cleans up some code left over from old helm and formally adds the `ProducesPerTokenLogProbabilities` capability to HuggingFaceSUT. I've also made a few subtle changes to how generation parameters are handled, aiming to avoid unintentional side effects.
- Don't pass a `generation_config` parameter. 
Instead, specify `pad_token_id` directly as a kwarg. Passing a generation config can have unintended consequences by overriding the model's default generation config, including parameters that we were not trying to change.
- Consistent handling of stop sequences.
Stop_sequences are always passed via the `stopping_criteria` parameter. Previously, single-token stop sequences were passed by setting `eos_token_id` instead, which leads to inconsistencies by altering the model's default configuration without clear disclosure to users.
- Pass `top_k` (if it was specified by the prompt).