### PR TITLE
Add remote attach debug option compatible with `poetry run`

### DIFF
--- a/modelgauge/main.py
+++ b/modelgauge/main.py
@@ -1,5 +1,6 @@
 import os
 import click
+import debugpy
 from modelgauge.base_test import PromptResponseTest
 from modelgauge.command_line import (
     DATA_DIR_OPTION,
@@ -183,6 +184,13 @@ def run_sut(
     default=False,
     help="Disable displaying the 'Processing TestItems' progress bar.",
 )
+@click.option(
+    "--debug",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Enable debugging with debugpy.",
+)
 def run_test(
     test: str,
     sut: str,
@@ -191,8 +199,16 @@ def run_test(
     output_file: Optional[str],
     no_caching: bool,
     no_progress_bar: bool,
+    debug: bool,
 ):
     """Run the Test on the desired SUT and output the TestRecord."""
+    if debug:
+        port = 5678
+        host = 'localhost'
+        print(f"Waiting for debugger to attach on {host}:{port}")
+        debugpy.listen((host, port))
+        debugpy.wait_for_client()
+
     secrets = load_secrets_from_config()
     # Check for missing secrets without instantiating any objects
     missing_secrets: List[MissingSecretValues] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ tomli = "^2.0.1"
 click = "^8.1.7"
 typing-extensions = "^4.10.0"
 tenacity = "^8.3.0"
+debugpy = "^1.8.1"
 
 [tool.poetry.group.dev.dependencies]
 modelgauge_demo_plugin = {path = "demo_plugin", develop = true, optional=true}


### PR DESCRIPTION
Allows for debugger attaching with debugpy (If using VSCode, will need to add an attach config in launch.json)
- Add `--debug` flag when running a test with poetry
- Test will pause before starting, allowing debugger to attach
- If you're using VSCode, you'll need to add a remote attach config to your launch.json. Use this guide: https://code.visualstudio.com/docs/editor/debugging#_launch-versus-attach-configurations
- The guide I used to find this solution: https://github.com/python-poetry/poetry/issues/5354#issuecomment-1852884176