### PR TITLE
Document interface for SUTs

### DIFF
--- a/docs/API/prompt.md
+++ b/docs/API/prompt.md
@@ -1,0 +1,6 @@
+::: modelgauge.prompt
+    options:
+        show_root_heading: true 
+        heading_level: 1
+        show_root_toc_entry: false  
+        show_if_no_docstring: true

--- a/docs/API/record_init.md
+++ b/docs/API/record_init.md
@@ -1,0 +1,6 @@
+::: modelgauge.record_init
+    options:
+        show_root_heading: true
+        show_root_toc_entry: false
+        heading_level: 1
+        show_if_no_docstring: true

--- a/docs/API/sut.md
+++ b/docs/API/sut.md
@@ -1,0 +1,22 @@
+::: modelgauge.sut
+    options:
+        show_root_heading: true
+        show_root_toc_entry: false
+        merge_init_into_class: true
+        show_if_no_docstring: false
+        show_bases: true
+        heading_level: 1
+        members:
+            - SUT
+            - PromptResponseSUT
+
+::: modelgauge.sut
+    options:
+        show_root_toc_entry: false
+        show_if_no_docstring: true
+        show_bases: false
+        members:
+            - SUTResponse
+            - SUTCompletion
+            - TopTokens
+            - TokenProbability

--- a/docs/API/sut_capabilities.md
+++ b/docs/API/sut_capabilities.md
@@ -1,0 +1,6 @@
+::: modelgauge.sut_capabilities
+    options:
+        show_root_heading: true
+        show_root_toc_entry: false
+        heading_level: 1
+        merge_init_into_class: true

--- a/docs/API/sut_decorator.md
+++ b/docs/API/sut_decorator.md
@@ -1,0 +1,5 @@
+::: modelgauge.sut_decorator
+    options:
+        show_root_heading: true
+        show_root_toc_entry: false
+        heading_level: 1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,9 +2,17 @@ site_name: ModelGauge
 repo_url: https://github.com/mlcommons/modelgauge/
 edit_uri: blob/main/docs/
 theme:
-  name: readthedocs
+  name: "material"
 plugins:
   - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_symbol_type_heading: true
+            show_signature_annotations: true
+            signature_crossrefs: true
+            docstring_section_style: table
 nav:
   - index.md
   - user_quick_start.md
@@ -16,3 +24,11 @@ nav:
   - plugins.md
   - design_philosophy.md
   - publishing.md
+  - API Reference:
+      - SUTs:
+        - sut: API/sut.md
+        - sut_capabilities: API/sut_capabilities.md
+        - sut_decorator: API/sut_decorator.md
+      - Data structures: # This can be organized differently.
+          - prompts: API/prompt.md
+          - initialization record: API/record_init.md

--- a/modelgauge/sut.py
+++ b/modelgauge/sut.py
@@ -45,7 +45,16 @@ class SUTResponse(BaseModel):
 
 
 class SUT(TrackedObject):
-    """Base class for all SUTs. There is no guaranteed interface between SUTs, so no methods here."""
+    """Base class for all SUTs.
+
+    SUT capabilities can be specified with the `@modelgauge_sut` decorator.
+    There is no guaranteed interface between SUTs, so no methods here.
+
+    Attributes:
+        uid (str): Unique identifier for this SUT.
+        capabilities: List of capabilities this SUT has.
+        initialization_record: The record of args and kwargs the SUT was initialized with.
+    """
 
     # Set automatically by @modelgauge_sut()
     capabilities: Sequence[Type[SUTCapability]]
@@ -57,18 +66,28 @@ class SUT(TrackedObject):
 
 
 class PromptResponseSUT(SUT, ABC, Generic[RequestType, ResponseType]):
-    """The base class for any SUT that is designed for handling a single-turn."""
+    """
+    Abstract base class that provides an interface to any SUT that is designed for handling a single-turn.
+
+    This class uses generics to allow for any type of native request and response objects.
+    """
 
     @not_implemented
     def translate_text_prompt(self, prompt: TextPrompt) -> RequestType:
-        """Convert the prompt into the SUT's native representation."""
+        """Convert the prompt into the SUT's native representation.
+
+        This method must be implemented if the SUT accepts text prompts.
+        """
         raise NotImplementedError(
             f"SUT {self.__class__.__name__} does not implement translate_text_prompt."
         )
 
     @not_implemented
     def translate_chat_prompt(self, prompt: ChatPrompt) -> RequestType:
-        """Convert the prompt into the SUT's native representation."""
+        """Convert the prompt into the SUT's native representation.
+
+        This method must be implemented if the SUT accepts chat prompts.
+        """
         raise NotImplementedError(
             f"SUT {self.__class__.__name__} does not implement translate_chat_prompt."
         )

--- a/modelgauge/sut_capabilities.py
+++ b/modelgauge/sut_capabilities.py
@@ -12,18 +12,31 @@ class SUTCapability(ABC):
 
 
 class AcceptsTextPrompt(SUTCapability):
+    """The capability to take a `TextPrompt` as input.
+
+    SUTs that report this capability must implement `translate_text_prompt()`.
+    """
     @classmethod
     def description(cls) -> str:
         return "These SUTs can take a `TextPrompt` as input."
 
 
 class AcceptsChatPrompt(SUTCapability):
+    """The capability to take a `ChatPrompt` as input.
+
+    SUTs that report this capability must implement `translate_chat_prompt()`.
+    """
+
     @classmethod
     def description(cls) -> str:
         return "These SUTs can take a `ChatPrompt` as input."
 
 
 class ProducesPerTokenLogProbabilities(SUTCapability):
+    """The capability to produce per-token log probabilities.
+
+    SUTs that report this capability must set the `top_logprobs` field in SUTResponse, if logprobs are requested.
+    """
     @classmethod
     def description(cls) -> str:
         return "These SUTs set the 'top_logprobs' field in SUTResponse."

--- a/modelgauge/sut_capabilities.py
+++ b/modelgauge/sut_capabilities.py
@@ -16,6 +16,7 @@ class AcceptsTextPrompt(SUTCapability):
 
     SUTs that report this capability must implement `translate_text_prompt()`.
     """
+
     @classmethod
     def description(cls) -> str:
         return "These SUTs can take a `TextPrompt` as input."
@@ -37,6 +38,7 @@ class ProducesPerTokenLogProbabilities(SUTCapability):
 
     SUTs that report this capability must set the `top_logprobs` field in SUTResponse, if logprobs are requested.
     """
+
     @classmethod
     def description(cls) -> str:
         return "These SUTs set the 'top_logprobs' field in SUTResponse."

--- a/modelgauge/sut_decorator.py
+++ b/modelgauge/sut_decorator.py
@@ -13,7 +13,11 @@ from typing import Sequence, Type
 
 
 def modelgauge_sut(capabilities: Sequence[Type[SUTCapability]]):
-    """Decorator providing common behavior and hooks for all ModelGauge SUTs."""
+    """Decorator providing common behavior and hooks for all ModelGauge SUTs.
+
+    Args:
+       capabilities: List of capabilities being reported by the SUT.
+    """
 
     def inner(cls):
         assert issubclass(


### PR DESCRIPTION
API reference for SUTs using mkdocs (already used for readthedocs) and the mkdocstrings plugins.
The documentation is loaded from docstrings and type hints.

https://github.com/mlcommons/modelgauge/assets/12498420/4316fc48-f754-4cbf-b4ab-e58ddae4ce0f


