### PR TITLE
safe-tests-use-modellab

### DIFF
--- a/plugins/standard_tests/modelgauge/tests/safe.py
+++ b/plugins/standard_tests/modelgauge/tests/safe.py
@@ -84,13 +84,13 @@ class SafeTest(PromptResponseTest):
         return f"{self.folder_name}_{self.hazard}_{persona.value}"
 
     def get_dependencies(self) -> Mapping[str, ExternalData]:
-        base_bucket_url = (
-            "https://storage.googleapis.com/mlc-safetest-dependencies-dev-e0441b1"
+        modellab_base_download_url = (
+            "https://ai-safety-dev.uc.r.appspot.com/files/download"
         )
         dependencies = {}
         for persona in self.persona_types:
             dependencies[self._persona_dependency_key(persona)] = WebData(
-                source_url=f"{base_bucket_url}/{self.folder_name}/mls_ais_wg_safe_{self.hazard}_{persona.value}-user.csv",
+                source_url=f"{modellab_base_download_url}/mls_ais_wg_safe_{self.hazard}_{persona.value}-user.csv",
             )
         return dependencies
 


### PR DESCRIPTION
Updating to use our current dev deployment of modellab to serve the files for safe tests. I'm not sure this is what we want to do! It might introduce some volatility to the tests and we might wind up reconsidering how we want to store files, but this serves as a reasonable proof of concept that it can work the way we expect it to.