### PR TITLE
Adds an optional cache to run-prompts

### DIFF
--- a/modelgauge/single_turn_prompt_response.py
+++ b/modelgauge/single_turn_prompt_response.py
@@ -35,7 +35,7 @@ class PromptWithContext(BaseModel):
 
     def __hash__(self):
         if self.source_id:
-            return hash(self.source_id)
+            return hash(self.source_id) + hash(self.prompt.text)
         else:
             return hash(self.prompt.text)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -550,6 +550,17 @@ files = [
 ]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+description = "Disk Cache -- Disk and file backed persistent cache."
+optional = false
+python-versions = ">=3"
+files = [
+    {file = "diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19"},
+    {file = "diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc"},
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.8"
 description = "Distribution utilities"
@@ -4007,4 +4018,4 @@ together = ["modelgauge_together"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "847073bfa84b905c03ac15f1f9e45efbcee2c12a93fe077f69f9c953c323990e"
+content-hash = "cbc64534c42fc43da67fd15d5094308094614a9c483cb545e903a1a98112fe15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ tomli = "^2.0.1"
 click = "^8.1.7"
 typing-extensions = "^4.10.0"
 tenacity = "^8.3.0"
+diskcache = "^5.6.3"
 
 [tool.poetry.group.dev.dependencies]
 modelgauge_demo_plugin = {path = "demo_plugin", develop = true, optional=true}

--- a/tests/test_notebook.ipynb
+++ b/tests/test_notebook.ipynb
@@ -27,8 +27,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from modelgauge.load_plugins import load_plugins\n",
     "# CLI functions\n",
-    "from modelgauge.main import run_test, run_sut, load_plugins\n",
+    "from modelgauge.main import run_test, run_sut\n",
     "from modelgauge.simple_test_runner import run_prompt_response_test\n",
     "from modelgauge.sut_registry import SUTS\n",
     "import os\n",

--- a/tests/test_prompt_pipeline.py
+++ b/tests/test_prompt_pipeline.py
@@ -3,7 +3,7 @@ import signal
 import time
 from csv import DictReader
 from typing import List
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/test_prompt_pipeline.py
+++ b/tests/test_prompt_pipeline.py
@@ -3,6 +3,7 @@ import signal
 import time
 from csv import DictReader
 from typing import List
+from unittest.mock import Mock, MagicMock
 
 import pytest
 
@@ -108,6 +109,38 @@ def test_csv_prompt_output(tmp_path, suts):
         assert items[0]["Text"] == "a"
         assert items[0]["fake1"] == "a1"
         assert items[0]["fake2"] == "a2"
+
+
+def test_prompt_sut_worker_normal(suts):
+    mock = MagicMock()
+    mock.return_value = FakeSUTResponse(completions=["a response"])
+    suts["fake1"].evaluate = mock
+    prompt_with_context = PromptWithContext(
+        source_id="1", prompt=TextPrompt(text="a prompt")
+    )
+
+    w = PromptSutWorkers(suts)
+    result = w.handle_item((prompt_with_context, "fake1"))
+
+    assert result == (prompt_with_context, "fake1", "a response")
+
+
+def test_prompt_sut_worker_cache(suts, tmp_path):
+    mock = MagicMock()
+    mock.return_value = FakeSUTResponse(completions=["a response"])
+    suts["fake1"].evaluate = mock
+    prompt_with_context = PromptWithContext(
+        source_id="1", prompt=TextPrompt(text="a prompt")
+    )
+
+    w = PromptSutWorkers(suts, cache_path=tmp_path)
+    result = w.handle_item((prompt_with_context, "fake1"))
+    assert result == (prompt_with_context, "fake1", "a response")
+    assert mock.call_count == 1
+
+    result = w.handle_item((prompt_with_context, "fake1"))
+    assert result == (prompt_with_context, "fake1", "a response")
+    assert mock.call_count == 1
 
 
 def test_full_run(suts):


### PR DESCRIPTION
You can now do things like this:

```
time modelgauge run-prompts  --sut gemma-7b-it --sut Mixtral-8x7B-Instruct-v0.1 --sut llama-3-70b-chat-hf --cache mycache  --workers 24 id_draft_id_elec_2024-06-28.csv
```

That will create the directory mycache and save all the responses there. The second time you run it, it's way faster.

I made it optional with an explicit cache dir so that cache management was firmly in the hands of the users. With more use, we could look at making it built in.

Note: for some reason this doesn't cache like 0.1% of the items on the first run. No idea why, but I'll look into it on Monday. But it's usable as is.