### PR TITLE
SUT response + annotation pipeline

### DIFF
--- a/demo_plugin/modelgauge/annotators/demo_annotator.py
+++ b/demo_plugin/modelgauge/annotators/demo_annotator.py
@@ -1,4 +1,5 @@
 from modelgauge.annotator import CompletionAnnotator
+from modelgauge.annotator_registry import ANNOTATORS
 from modelgauge.single_turn_prompt_response import PromptWithContext
 from modelgauge.sut import SUTCompletion
 from pydantic import BaseModel
@@ -40,3 +41,6 @@ class DemoYBadAnnotator(CompletionAnnotator[DemoYBadAnnotation]):
         self, request, response: DemoYBadResponse
     ) -> DemoYBadAnnotation:
         return DemoYBadAnnotation(badness=response.score)
+
+
+ANNOTATORS.register(DemoYBadAnnotator, "demo_annotator")

--- a/modelgauge/annotation_pipeline.py
+++ b/modelgauge/annotation_pipeline.py
@@ -48,20 +48,15 @@ class CsvAnnotatorInput(AnnotatorInput):
 
 
 class JsonlAnnotatorOutput(PromptOutput):
-    def __init__(self, path, annotators):
+    def __init__(self, path):
         super().__init__()
         self.path = path
-        self.annotators = annotators
         self.file = None
         self.writer = None
 
     def __enter__(self):
         self.file = open(self.path, "w", newline="")
         self.writer = jsonlines.Writer(self.file)
-        # headers = ["UID", "Prompt", "SUT", "Response"]
-        # for a in self.annotators.keys():
-        #     headers += [a + "_is_safe", a + "_violation_categories"]
-        # self.writer.write(headers)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -80,9 +75,6 @@ class JsonlAnnotatorOutput(PromptOutput):
         }
         self.writer.write(output_obj)
 
-    # def launder_the_type_problem(self, item) -> str:
-    #     return item.prompt.text
-
 
 class AnnotatorSource(Source):
     def __init__(self, input: AnnotatorInput):
@@ -98,7 +90,7 @@ class AnnotatorAssigner(Pipe):
         super().__init__()
         self.annotators = annotators
 
-    def handle_item(self, item):
+    def handle_item(self, item: SutInteraction):
         for annotator_uid in self.annotators:
             self.downstream_put((item, annotator_uid))
 

--- a/modelgauge/annotation_pipeline.py
+++ b/modelgauge/annotation_pipeline.py
@@ -14,6 +14,8 @@ from modelgauge.prompt_pipeline import PromptOutput, SutInteraction
 from modelgauge.single_turn_prompt_response import PromptWithContext
 from modelgauge.sut import PromptResponseSUT, SUTCompletion
 
+ANNOTATOR_CSV_INPUT_COLUMNS = ["UID", "Prompt", "SUT", "Response"]
+
 
 class AnnotatorInput(metaclass=ABCMeta):
     @abstractmethod
@@ -31,6 +33,7 @@ class CsvAnnotatorInput(AnnotatorInput):
     def __init__(self, path):
         super().__init__()
         self.path = path
+        self._validate_file()
 
     def __iter__(self) -> Iterable[SutInteraction]:
         with open(self.path, newline="") as f:
@@ -46,10 +49,22 @@ class CsvAnnotatorInput(AnnotatorInput):
                 response = SUTCompletion(text=row["Response"])
                 yield SutInteraction(prompt, row["SUT"], response)
 
+    def _validate_file(self):
+        with open(self.path, newline="") as f:
+            csvreader = csv.reader(f)
+            columns = next(csvreader)
+        assert all(
+            c in columns for c in ANNOTATOR_CSV_INPUT_COLUMNS
+        ), f"Invalid input file. Must have columns: {', '.join(ANNOTATOR_CSV_INPUT_COLUMNS)}."
+
 
 class JsonlAnnotatorOutput(PromptOutput):
     def __init__(self, path):
         super().__init__()
+        assert (
+            path.suffix.lower() == ".jsonl"
+        ), f"Invalid output file {path}. Must be of type JSONL."
+
         self.path = path
         self.file = None
         self.writer = None

--- a/modelgauge/main.py
+++ b/modelgauge/main.py
@@ -390,7 +390,7 @@ def run_annotators(annotator_uids, workers, filename, debug):
         + datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
         + ".jsonl"
     )
-    output = JsonlAnnotatorOutput(output_path, annotators)
+    output = JsonlAnnotatorOutput(output_path)
 
     prompt_count = len(input)
 

--- a/modelgauge/pipeline_runner.py
+++ b/modelgauge/pipeline_runner.py
@@ -1,0 +1,162 @@
+import click
+from typing import Mapping, Optional
+
+from modelgauge.annotation_pipeline import (
+    AnnotatorAssigner,
+    AnnotatorSink,
+    AnnotatorSource,
+    AnnotatorWorkers,
+    CsvAnnotatorInput,
+    JsonlAnnotatorOutput,
+)
+from modelgauge.annotator import CompletionAnnotator
+from modelgauge.pipeline import Pipeline
+from modelgauge.prompt_pipeline import (
+    PromptSource,
+    PromptSutAssigner,
+    PromptSutWorkers,
+    PromptSink,
+    CsvPromptInput,
+    CsvPromptOutput,
+)
+from modelgauge.sut import PromptResponseSUT
+from modelgauge.sut_capabilities import AcceptsTextPrompt
+
+
+def build_prompt_pipeline_segments(
+    suts,
+    input_path,
+    output_path: Optional = None,
+    workers: Optional = None,
+    sut_cache_dir: Optional = None,
+    include_sink=True,
+):
+    segments = []
+    input = CsvPromptInput(input_path)
+    segments.append(PromptSource(input))
+    segments.append(PromptSutAssigner(suts))
+    segments.append(PromptSutWorkers(suts, workers, cache_path=sut_cache_dir))
+    if include_sink:
+        assert (
+            output_path is not None
+        ), "output_path must be provided if include_sink=True."
+        assert output_path.suffix == ".csv", "Prompt output must have a .csv extension."
+        output = CsvPromptOutput(output_path, suts)
+        segments.append(PromptSink(suts, output))
+    return segments
+
+
+def build_annotator_pipeline_segments(
+    annotators,
+    output_path,
+    input_path: Optional = None,
+    workers: Optional = None,
+    include_source=True,
+):
+    assert (
+        output_path.suffix == ".jsonl"
+    ), "Annotator output must have a .jsonl extension."
+    segments = []
+    if include_source:
+        assert (
+            input_path is not None
+        ), "input_path must be provided if include_source=True."
+        input = CsvAnnotatorInput(input_path)
+        segments.append(AnnotatorSource(input))
+    segments.append(AnnotatorAssigner(annotators))
+    segments.append(AnnotatorWorkers(annotators, workers))
+    output = JsonlAnnotatorOutput(output_path)
+    segments.append(AnnotatorSink(annotators, output))
+    return segments
+
+
+def run_prompts_pipeline(
+    suts: Mapping[str, PromptResponseSUT],
+    workers,
+    sut_cache_dir,
+    debug,
+    input_path,
+    output_path,
+    annotators: Optional[Mapping[str, CompletionAnnotator]] = None,
+):
+    """Runs a pipeline for a given CSV file of prompts over a set of SUTs."""
+    # TODO: Check CSV
+    run_annotators = annotators is not None and len(annotators)
+
+    if sut_cache_dir:
+        print(f"Creating cache dir {sut_cache_dir}")
+        sut_cache_dir.mkdir(exist_ok=True)
+
+    for sut_uid in suts:
+        sut = suts[sut_uid]
+        if not AcceptsTextPrompt in sut.capabilities:
+            raise click.BadParameter(f"{sut_uid} does not accept text prompts")
+    pipeline_segments = []
+    if run_annotators:
+        # Adds annotator pipes after prompt pipes. Uses annotator output sink instead of regular prompt output.
+        pipeline_segments.extend(
+            build_prompt_pipeline_segments(
+                suts,
+                input_path,
+                workers=workers,
+                sut_cache_dir=sut_cache_dir,
+                include_sink=False,
+            )
+        )
+        pipeline_segments.extend(
+            build_annotator_pipeline_segments(
+                annotators, output_path, workers=workers, include_source=False
+            )
+        )
+        num_input_items = len(pipeline_segments[0].input)
+        total_items = num_input_items * len(suts) * len(annotators)
+        print(
+            f"Processing {num_input_items} prompts * {len(suts)} SUTS * {len(annotators)} annotators."
+        )
+    else:
+        pipeline_segments = build_prompt_pipeline_segments(
+            suts,
+            input_path,
+            output_path,
+            workers=workers,
+            sut_cache_dir=sut_cache_dir,
+            include_sink=True,
+        )
+        num_input_items = len(pipeline_segments[0].input)
+        total_items = num_input_items * len(suts)
+        print(f"Processing {num_input_items} prompts * {len(suts)} SUTS)")
+
+    run_pipeline(pipeline_segments, total_items, debug)
+    print(f"output saved to {output_path}")
+
+
+def run_annotator_pipeline(annotators, workers, debug, input_path, output_path):
+    # TODO: Check CSV has right columns
+    pipeline_segments = build_annotator_pipeline_segments(
+        annotators, output_path, input_path=input_path, workers=workers
+    )
+    num_input_items = len(pipeline_segments[0].input)
+    total_items = num_input_items * len(annotators)
+    print(f"Processing {num_input_items} items * {len(annotators)} annotators.")
+
+    run_pipeline(pipeline_segments, total_items, debug)
+    print(f"output saved to {output_path}")
+
+
+def run_pipeline(pipeline_segments, total_items, debug):
+    with click.progressbar(length=total_items) as bar:
+        last_complete_count = 0
+
+        def show_progress(data):
+            nonlocal last_complete_count
+            complete_count = data["completed"]
+            bar.update(complete_count - last_complete_count)
+            last_complete_count = complete_count
+
+        pipeline = Pipeline(
+            *pipeline_segments,
+            progress_callback=show_progress,
+            debug=debug,
+        )
+
+        pipeline.run()

--- a/modelgauge/pipeline_runner.py
+++ b/modelgauge/pipeline_runner.py
@@ -29,6 +29,7 @@ def build_prompt_pipeline_segments(
     sut_cache_dir=None,
     include_sink=True,
 ):
+    """Returns an in-order list of pipeline segments required for a prompt pipeline."""
     segments: List[PipelineSegment] = []
     input = CsvPromptInput(input_path)
     segments.append(PromptSource(input))
@@ -38,7 +39,6 @@ def build_prompt_pipeline_segments(
         assert (
             output_path is not None
         ), "output_path must be provided if include_sink=True."
-        assert output_path.suffix == ".csv", "Prompt output must have a .csv extension."
         output = CsvPromptOutput(output_path, suts)
         segments.append(PromptSink(suts, output))
     return segments
@@ -47,9 +47,7 @@ def build_prompt_pipeline_segments(
 def build_annotator_pipeline_segments(
     annotators, output_path, input_path=None, workers=None, include_source=True
 ):
-    assert (
-        output_path.suffix == ".jsonl"
-    ), "Annotator output must have a .jsonl extension."
+    """Returns an in-order list of pipeline segments required for an annotator pipeline."""
     segments: List[PipelineSegment] = []
     if include_source:
         assert (
@@ -68,7 +66,6 @@ def run_prompts_pipeline(
     suts, workers, sut_cache_dir, debug, input_path, output_path, annotators=None
 ):
     """Runs a pipeline for a given CSV file of prompts over a set of SUTs."""
-    # TODO: Check CSV
     run_annotators = annotators is not None and len(annotators)
 
     if sut_cache_dir:
@@ -118,7 +115,6 @@ def run_prompts_pipeline(
 
 
 def run_annotator_pipeline(annotators, workers, debug, input_path, output_path):
-    # TODO: Check CSV has right columns
     pipeline_segments = build_annotator_pipeline_segments(
         annotators, output_path, input_path=input_path, workers=workers
     )

--- a/modelgauge/prompt_pipeline.py
+++ b/modelgauge/prompt_pipeline.py
@@ -166,15 +166,3 @@ class PromptSink(Sink):
             self.writer.write(item.prompt, self.unfinished[item.prompt])
             self._debug(f"wrote {item.prompt}")
             del self.unfinished[item.prompt]
-
-
-def create_prompt_source(path):
-    input = CsvPromptInput(path)
-    return PromptSource(input)
-
-
-def create_promp_pipes(suts, workers, cache_path):
-    return [
-        PromptSutAssigner(suts),
-        PromptSutWorkers(suts, workers=workers, cache_path=cache_path),
-    ]

--- a/modelgauge/prompt_pipeline.py
+++ b/modelgauge/prompt_pipeline.py
@@ -106,7 +106,7 @@ class PromptSource(Source):
         super().__init__()
         self.input = input
 
-    def new_item_iterable(self) -> Iterable[PromptWithContext]:
+    def new_item_iterable(self):
         return self.input
 
 

--- a/modelgauge/prompt_pipeline.py
+++ b/modelgauge/prompt_pipeline.py
@@ -166,3 +166,15 @@ class PromptSink(Sink):
             self.writer.write(item.prompt, self.unfinished[item.prompt])
             self._debug(f"wrote {item.prompt}")
             del self.unfinished[item.prompt]
+
+
+def create_prompt_source(path):
+    input = CsvPromptInput(path)
+    return PromptSource(input)
+
+
+def create_promp_pipes(suts, workers, cache_path):
+    return [
+        PromptSutAssigner(suts),
+        PromptSutWorkers(suts, workers=workers, cache_path=cache_path),
+    ]

--- a/modelgauge/prompt_pipeline.py
+++ b/modelgauge/prompt_pipeline.py
@@ -106,7 +106,7 @@ class PromptSource(Source):
         super().__init__()
         self.input = input
 
-    def new_item_iterable(self):
+    def new_item_iterable(self) -> Iterable[PromptWithContext]:
         return self.input
 
 

--- a/modelgauge/prompt_pipeline.py
+++ b/modelgauge/prompt_pipeline.py
@@ -11,6 +11,8 @@ from modelgauge.prompt import TextPrompt
 from modelgauge.single_turn_prompt_response import PromptWithContext
 from modelgauge.sut import PromptResponseSUT, SUT, SUTCompletion
 
+PROMPT_CSV_INPUT_COLUMNS = ["UID", "Text"]
+
 
 @dataclass
 class SutInteraction:
@@ -43,6 +45,7 @@ class CsvPromptInput(PromptInput):
     def __init__(self, path):
         super().__init__()
         self.path = path
+        self._validate_file()
 
     def __iter__(self) -> Iterable[PromptWithContext]:
         with open(self.path, newline="") as f:
@@ -55,7 +58,14 @@ class CsvPromptInput(PromptInput):
                     # Context can be any type you want.
                     context=row,
                 )
-                # yield PromptItem(row)
+
+    def _validate_file(self):
+        with open(self.path, newline="") as f:
+            csvreader = csv.reader(f)
+            columns = next(csvreader)
+        assert all(
+            c in columns for c in PROMPT_CSV_INPUT_COLUMNS
+        ), f"Invalid input file. Must have columns: {', '.join(PROMPT_CSV_INPUT_COLUMNS)}."
 
 
 class PromptOutput(metaclass=ABCMeta):
@@ -73,6 +83,10 @@ class PromptOutput(metaclass=ABCMeta):
 class CsvPromptOutput(PromptOutput):
     def __init__(self, path, suts):
         super().__init__()
+        assert (
+            path.suffix.lower() == ".csv"
+        ), f"Invalid output file {path}. Must be of type CSV."
+
         self.path = path
         self.suts = suts
         self.file = None
@@ -81,8 +95,7 @@ class CsvPromptOutput(PromptOutput):
     def __enter__(self):
         self.file = open(self.path, "w", newline="")
         self.writer = csv.writer(self.file, quoting=csv.QUOTE_ALL)
-        headers = ["UID", "Text"]
-        self.writer.writerow(headers + [s for s in self.suts.keys()])
+        self.writer.writerow(PROMPT_CSV_INPUT_COLUMNS + [s for s in self.suts.keys()])
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/tests/test_annotation_pipeline.py
+++ b/tests/test_annotation_pipeline.py
@@ -86,6 +86,24 @@ def test_csv_annotator_input(tmp_path):
     assert sut_interactions_is_equal(item, make_sut_interaction("1", "a", "s", "b"))
 
 
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Prompt,UID,Extra,Response,Response\n",
+        "UID,Prompt,SUT\n",
+        "Extra,Response,Extra\n",
+    ],
+)
+def test_csv_annotator_input_invalid_columns(tmp_path, header):
+    file_path = tmp_path / "input.csv"
+    file_path.write_text(header)
+    with pytest.raises(
+        AssertionError,
+        match="Invalid input file. Must have columns: UID, Prompt, SUT, Response.",
+    ):
+        CsvAnnotatorInput(file_path)
+
+
 def test_json_annotator_output(tmp_path):
     file_path = tmp_path / "output.jsonl"
     with JsonlAnnotatorOutput(file_path) as output:
@@ -123,6 +141,15 @@ def test_json_annotator_output_different_annotation_types(tmp_path):
 
     with jsonlines.open(file_path) as reader:
         assert reader.read()["Annotations"] == annotations
+
+
+@pytest.mark.parametrize("output_fname", ["output.csv", "output.json"])
+def test_csv_annotator_output_invalid(tmp_path, output_fname):
+    file_path = tmp_path / output_fname
+    with pytest.raises(
+        AssertionError, match=f"Invalid output file {file_path}. Must be of type JSONL."
+    ):
+        JsonlAnnotatorOutput(file_path)
 
 
 @pytest.fixture

--- a/tests/test_annotation_pipeline.py
+++ b/tests/test_annotation_pipeline.py
@@ -2,6 +2,7 @@ import itertools
 import jsonlines
 import pytest
 import time
+from unittest.mock import MagicMock
 
 from modelgauge.annotation_pipeline import (
     SutInteraction,
@@ -15,13 +16,20 @@ from modelgauge.annotation_pipeline import (
 )
 from modelgauge.pipeline import Pipeline
 from modelgauge.prompt import TextPrompt
-from modelgauge.prompt_pipeline import PromptOutput
+from modelgauge.prompt_pipeline import (
+    PromptOutput,
+    PromptSource,
+    PromptSutAssigner,
+    PromptSutWorkers,
+)
 from modelgauge.single_turn_prompt_response import PromptWithContext
 from modelgauge.sut import SUTCompletion
 from tests.fake_annotator import (
     FakeAnnotation,
     FakeAnnotator,
 )
+from tests.fake_sut import FakeSUT
+from tests.test_prompt_pipeline import FakePromptInput
 
 
 class FakeAnnotatorInput(AnnotatorInput):
@@ -44,18 +52,13 @@ class FakeAnnotatorInput(AnnotatorInput):
 
 class FakeAnnotatorOutput(PromptOutput):
     def __init__(self):
-        self.output = []
+        self.output = {}
 
     def write(self, item, annotations):
-        self.output.append((item, annotations))
+        self.output[item] = annotations
 
 
-@pytest.fixture
-def annotators():
-    return {"fake1": FakeAnnotator(), "fake2": FakeAnnotator()}
-
-
-def make_input_sample(source_id, prompt, sut_uid, response):
+def make_sut_interaction(source_id, prompt, sut_uid, response):
     return SutInteraction(
         PromptWithContext(source_id=source_id, prompt=TextPrompt(text=prompt)),
         sut_uid,
@@ -63,26 +66,31 @@ def make_input_sample(source_id, prompt, sut_uid, response):
     )
 
 
+def sut_interactions_is_equal(a, b):
+    """Equality check that ignores the prompt's context attribute."""
+    return (
+        a.prompt.source_id == b.prompt.source_id
+        and a.prompt.prompt.text == b.prompt.prompt.text
+        and a.sut_uid == b.sut_uid
+        and a.response == b.response
+    )
+
+
 def test_csv_annotator_input(tmp_path):
     file_path = tmp_path / "input.csv"
-    file_path.write_text('UID,Prompt,SUT,Response\n"1","a","sut_uid","b"')
+    file_path.write_text('UID,Prompt,SUT,Response\n"1","a","s","b"')
     input = CsvAnnotatorInput(file_path)
 
     assert len(input) == 1
     item: SutInteraction = next(iter(input))
-    assert item.prompt.prompt == TextPrompt(text="a")
-    assert item.prompt.source_id == "1"
-    assert item.sut_uid == "sut_uid"
-    assert item.response == SUTCompletion(text="b")
+    assert sut_interactions_is_equal(item, make_sut_interaction("1", "a", "s", "b"))
 
 
-def test_json_annotator_output(tmp_path, annotators):
+def test_json_annotator_output(tmp_path):
     file_path = tmp_path / "output.jsonl"
-    input_sample1 = make_input_sample("1", "a", "sut_uid1", "b")
-    input_sample2 = make_input_sample("2", "c", "sut_uid2", "d")
-    with JsonlAnnotatorOutput(file_path, annotators) as output:
-        output.write(input_sample1, {"fake1": "a1", "fake2": "a2"})
-        output.write(input_sample2, {"fake1": "a3", "fake2": "a4"})
+    with JsonlAnnotatorOutput(file_path) as output:
+        output.write(make_sut_interaction("1", "a", "sut1", "b"), {"fake": "x"})
+        output.write(make_sut_interaction("2", "c", "sut2", "d"), {"fake": "y"})
 
     with jsonlines.open(file_path) as reader:
         items: list[dict] = [i for i in reader]
@@ -90,36 +98,43 @@ def test_json_annotator_output(tmp_path, annotators):
         assert items[0] == {
             "UID": "1",
             "Prompt": "a",
-            "SUT": "sut_uid1",
+            "SUT": "sut1",
             "Response": "b",
-            "Annotations": {"fake1": "a1", "fake2": "a2"},
+            "Annotations": {"fake": "x"},
         }
         assert items[1] == {
             "UID": "2",
             "Prompt": "c",
-            "SUT": "sut_uid2",
+            "SUT": "sut2",
             "Response": "d",
-            "Annotations": {"fake1": "a3", "fake2": "a4"},
+            "Annotations": {"fake": "y"},
         }
 
 
-def test_json_annotator_output_dict_annotation(tmp_path, annotators):
+def test_json_annotator_output_different_annotation_types(tmp_path):
     file_path = tmp_path / "output.jsonl"
+    annotations = {
+        "fake1": {"sut_text": "a"},
+        "fake2": {"sut_text": "b", "num": 0},
+        "fake3": "c",
+    }
+    with JsonlAnnotatorOutput(file_path) as output:
+        output.write(make_sut_interaction("1", "a", "s", "b"), annotations)
 
-    with JsonlAnnotatorOutput(file_path, annotators) as output:
-        output.write(
-            make_input_sample("1", "a", "sut_uid1", "b"),
-            {
-                "fake1": FakeAnnotation(sut_text="a1").model_dump(),
-                "fake2": FakeAnnotation(sut_text="a2").model_dump(),
-            },
-        )
     with jsonlines.open(file_path) as reader:
-        items: list[dict] = [i for i in reader]
-        assert items[0]["Annotations"] == {
-            "fake1": {"sut_text": "a1"},
-            "fake2": {"sut_text": "a2"},
+        assert reader.read()["Annotations"] == annotations
+
+
+@pytest.fixture
+def annotators():
+    annotator = FakeAnnotator()
+    annotator.translate_response = MagicMock(
+        side_effect=lambda _, response: {
+            "sut_text": response.sut_text,
+            "dummy": "d",
         }
+    )
+    return {"fake1": FakeAnnotator(), "fake2": annotator}
 
 
 def test_full_run(annotators):
@@ -130,7 +145,6 @@ def test_full_run(annotators):
         ]
     )
     output = FakeAnnotatorOutput()
-
     p = Pipeline(
         AnnotatorSource(input),
         AnnotatorAssigner(annotators),
@@ -138,25 +152,26 @@ def test_full_run(annotators):
         AnnotatorSink(annotators, output),
         debug=True,
     )
-
     p.run()
 
     assert len(output.output) == len(input.items)
-    assert sorted([r[0].prompt.source_id for r in output.output]) == [
-        i["UID"] for i in input.items
-    ]
-    assert sorted([r[0].response.text for r in output.output]) == [
-        i["Response"] for i in input.items
-    ]
-    row1 = output.output[0]
-    assert "fake1" in row1[1]
-    assert "fake2" in row1[1]
-    row2 = output.output[1]
-    assert "fake1" in row2[1]
-    assert "fake2" in row2[1]
+    interactions = sorted(list(output.output.keys()), key=lambda o: o.prompt.source_id)
+    assert sut_interactions_is_equal(
+        interactions[0], make_sut_interaction("1", "a", "s", "b")
+    )
+    assert output.output[interactions[0]] == {
+        "fake1": {"sut_text": "b"},
+        "fake2": {"sut_text": "b", "dummy": "d"},
+    }
+    assert sut_interactions_is_equal(
+        interactions[1], make_sut_interaction("2", "c", "s", "d")
+    )
+    assert output.output[interactions[1]] == {
+        "fake1": {"sut_text": "d"},
+        "fake2": {"sut_text": "d", "dummy": "d"},
+    }
 
 
-#
 def test_progress(annotators):
     input = FakeAnnotatorInput(
         [
@@ -182,3 +197,41 @@ def test_progress(annotators):
 
     assert progress_items[0]["completed"] == 0
     assert progress_items[-1]["completed"] == 4
+
+
+def test_prompt_response_annotation_pipeline(annotators):
+    input = FakePromptInput(
+        [
+            {"UID": "1", "Text": "a"},
+            {"UID": "2", "Text": "b"},
+        ]
+    )
+    output = FakeAnnotatorOutput()
+
+    suts = {"sut1": FakeSUT(), "sut2": FakeSUT()}
+    p = Pipeline(
+        PromptSource(input),
+        PromptSutAssigner(suts),
+        PromptSutWorkers(suts, workers=1),
+        AnnotatorAssigner(annotators),
+        AnnotatorWorkers(annotators, workers=1),
+        AnnotatorSink(annotators, output),
+    )
+    p.run()
+
+    assert len(output.output) == len(input.items) * len(suts)
+    interactions = sorted(
+        list(output.output.keys()), key=lambda o: (o.prompt.source_id, o.sut_uid)
+    )
+    for interaction, prompt_sut in zip(
+        interactions, itertools.product(input.items, suts)
+    ):
+        prompt, sut = prompt_sut
+        assert sut_interactions_is_equal(
+            interaction,
+            make_sut_interaction(prompt["UID"], prompt["Text"], sut, prompt["Text"]),
+        )
+        assert output.output[interaction] == {
+            "fake1": {"sut_text": prompt["Text"]},
+            "fake2": {"sut_text": prompt["Text"], "dummy": "d"},
+        }

--- a/tests/test_annotation_pipeline.py
+++ b/tests/test_annotation_pipeline.py
@@ -199,7 +199,13 @@ def test_progress(annotators):
     assert progress_items[-1]["completed"] == 4
 
 
-def test_prompt_response_annotation_pipeline(annotators):
+@pytest.mark.parametrize(
+    "sut_worker_count,annotator_worker_count",
+    [(1, 1), (2, 2), (8, 8), (1, 5), (5, 1), (3, 9), (9, 3)],
+)
+def test_prompt_response_annotation_pipeline(
+    annotators, sut_worker_count, annotator_worker_count
+):
     input = FakePromptInput(
         [
             {"UID": "1", "Text": "a"},
@@ -212,9 +218,9 @@ def test_prompt_response_annotation_pipeline(annotators):
     p = Pipeline(
         PromptSource(input),
         PromptSutAssigner(suts),
-        PromptSutWorkers(suts, workers=1),
+        PromptSutWorkers(suts, workers=sut_worker_count),
         AnnotatorAssigner(annotators),
-        AnnotatorWorkers(annotators, workers=1),
+        AnnotatorWorkers(annotators, workers=annotator_worker_count),
         AnnotatorSink(annotators, output),
     )
     p.run()

--- a/tests/test_annotation_pipeline.py
+++ b/tests/test_annotation_pipeline.py
@@ -4,7 +4,7 @@ import pytest
 import time
 
 from modelgauge.annotation_pipeline import (
-    AnnotatorInputSample,
+    SutInteraction,
     AnnotatorInput,
     AnnotatorSource,
     AnnotatorAssigner,
@@ -39,7 +39,7 @@ class FakeAnnotatorInput(AnnotatorInput):
                 context=row,
             )
             response = SUTCompletion(text=row["Response"])
-            yield AnnotatorInputSample(prompt, row["SUT"], response)
+            yield SutInteraction(prompt, row["SUT"], response)
 
 
 class FakeAnnotatorOutput(PromptOutput):
@@ -56,7 +56,7 @@ def annotators():
 
 
 def make_input_sample(source_id, prompt, sut_uid, response):
-    return AnnotatorInputSample(
+    return SutInteraction(
         PromptWithContext(source_id=source_id, prompt=TextPrompt(text=prompt)),
         sut_uid,
         SUTCompletion(text=response),
@@ -69,7 +69,7 @@ def test_csv_annotator_input(tmp_path):
     input = CsvAnnotatorInput(file_path)
 
     assert len(input) == 1
-    item: AnnotatorInputSample = next(iter(input))
+    item: SutInteraction = next(iter(input))
     assert item.prompt.prompt == TextPrompt(text="a")
     assert item.prompt.source_id == "1"
     assert item.sut_uid == "sut_uid"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,6 +110,43 @@ def test_run_prompts_normal(tmp_path):
         assert row2["demo_yes_no"] == "No"
 
 
+def test_run_prompts_with_annotators(tmp_path):
+    in_path = create_prompts_file(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        main.modelgauge_cli,
+        [
+            "run-prompts",
+            "--sut",
+            "demo_yes_no",
+            "--annotator",
+            "demo_annotator",
+            "--workers",
+            "5",
+            str(in_path),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    out_path = re.findall(r"\S+\.jsonl", result.stdout)[0]
+    with jsonlines.open(tmp_path / out_path) as reader:
+        assert reader.read() == {
+            "UID": "p1",
+            "Prompt": "Say yes",
+            "SUT": "demo_yes_no",
+            "Response": "Yes",
+            "Annotations": {"demo_annotator": {"badness": 1.0}},
+        }
+        assert reader.read() == {
+            "UID": "p2",
+            "Prompt": "Refuse",
+            "SUT": "demo_yes_no",
+            "Response": "No",
+            "Annotations": {"demo_annotator": {"badness": 0.0}},
+        }
+
+
 @modelgauge_sut(capabilities=[])
 class NoReqsSUT(SUT):
     pass
@@ -151,9 +188,6 @@ def test_run_annotators(tmp_path):
         ],
         catch_exceptions=False,
     )
-
-    print(result.output)
-
     assert result.exit_code == 0
 
     out_path = re.findall(r"\S+\.jsonl", result.stdout)[0]
@@ -172,6 +206,3 @@ def test_run_annotators(tmp_path):
             "Response": "No",
             "Annotations": {"demo_annotator": {"badness": 0.0}},
         }
-
-
-# TODO: Add tesst for full prompt -> response - > annotator pipeline

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import csv
+import jsonlines
 import re
 
 import pytest
@@ -76,12 +77,15 @@ def test_run_test_demos(test):
     assert re.search(r"Full TestRecord json written to output", result.output)
 
 
-def test_run_prompts_normal(tmp_path):
-    in_path = (tmp_path / "input.csv").absolute()
-
+def create_prompts_file(path):
+    in_path = (path / "input.csv").absolute()
     with open(in_path, "w") as f:
         f.write("UID,Text,Ignored\np1,Say yes,ignored\np2,Refuse,ignored\n")
+    return in_path
 
+
+def test_run_prompts_normal(tmp_path):
+    in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
@@ -92,7 +96,7 @@ def test_run_prompts_normal(tmp_path):
     assert result.exit_code == 0
 
     out_path = re.findall(r"\S+\.csv", result.stdout)[0]
-    with open(in_path.parent / out_path, "r") as f:
+    with open(tmp_path / out_path, "r") as f:
         reader = csv.DictReader(f)
 
         row1 = next(reader)
@@ -112,12 +116,8 @@ class NoReqsSUT(SUT):
 
 
 def test_run_prompts_bad_sut(tmp_path):
+    in_path = create_prompts_file(tmp_path)
     SUTS.register(NoReqsSUT, "noreqs")
-
-    in_path = (tmp_path / "input.csv").absolute()
-
-    with open(in_path, "w") as f:
-        f.write("UID,Text,Ignored\np1,Say yes,ignored\n")
 
     runner = CliRunner()
     result = runner.invoke(
@@ -127,3 +127,56 @@ def test_run_prompts_bad_sut(tmp_path):
     )
     assert result.exit_code == 2
     assert re.search(r"noreqs does not accept text prompts", str(result.output))
+
+
+def create_prompt_responses_file(path):
+    in_path = (path / "input.csv").absolute()
+    with open(in_path, "w") as f:
+        f.write(
+            "UID,Prompt,SUT,Response\np1,Say yes,demo_yes_no,Yes\np2,Refuse,demo_yes_no,No\n"
+        )
+    return in_path
+
+
+@pytest.mark.parametrize(
+    "create_input,sut_options",
+    [
+        (create_prompts_file, ["--sut", "demo_yes_no"]),
+        (create_prompt_responses_file, []),
+    ],
+)
+def test_run_annotators(tmp_path, create_input, sut_options):
+    in_path = create_input(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        main.modelgauge_cli,
+        [
+            "run-prompts",
+            "--annotator",
+            "demo_annotator",
+            *sut_options,
+            str(in_path),
+        ],
+        catch_exceptions=False,
+    )
+
+    print(result.output)
+
+    assert result.exit_code == 0
+
+    out_path = re.findall(r"\S+\.jsonl", result.stdout)[0]
+    with jsonlines.open(tmp_path / out_path) as reader:
+        assert reader.read() == {
+            "UID": "p1",
+            "Prompt": "Say yes",
+            "SUT": "demo_yes_no",
+            "Response": "Yes",
+            "Annotations": {"demo_annotator": {"badness": 1.0}},
+        }
+        assert reader.read() == {
+            "UID": "p2",
+            "Prompt": "Refuse",
+            "SUT": "demo_yes_no",
+            "Response": "No",
+            "Annotations": {"demo_annotator": {"badness": 0.0}},
+        }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,23 +138,15 @@ def create_prompt_responses_file(path):
     return in_path
 
 
-@pytest.mark.parametrize(
-    "create_input,sut_options",
-    [
-        (create_prompts_file, ["--sut", "demo_yes_no"]),
-        (create_prompt_responses_file, []),
-    ],
-)
-def test_run_annotators(tmp_path, create_input, sut_options):
-    in_path = create_input(tmp_path)
+def test_run_annotators(tmp_path):
+    in_path = create_prompt_responses_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
         [
-            "run-prompts",
+            "run-annotators",
             "--annotator",
             "demo_annotator",
-            *sut_options,
             str(in_path),
         ],
         catch_exceptions=False,
@@ -180,3 +172,6 @@ def test_run_annotators(tmp_path, create_input, sut_options):
             "Response": "No",
             "Annotations": {"demo_annotator": {"badness": 0.0}},
         }
+
+
+# TODO: Add tesst for full prompt -> response - > annotator pipeline

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,7 +89,7 @@ def test_run_prompts_normal(tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-prompts", "--sut", "demo_yes_no", str(in_path)],
+        ["run-csv-items", "--sut", "demo_yes_no", str(in_path)],
         catch_exceptions=False,
     )
 
@@ -116,7 +116,7 @@ def test_run_prompts_with_annotators(tmp_path):
     result = runner.invoke(
         main.modelgauge_cli,
         [
-            "run-prompts",
+            "run-csv-items",
             "--sut",
             "demo_yes_no",
             "--annotator",
@@ -159,7 +159,7 @@ def test_run_prompts_bad_sut(tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-prompts", "--sut", "noreqs", str(in_path)],
+        ["run-csv-items", "--sut", "noreqs", str(in_path)],
         catch_exceptions=False,
     )
     assert result.exit_code == 2
@@ -181,7 +181,7 @@ def test_run_annotators(tmp_path):
     result = runner.invoke(
         main.modelgauge_cli,
         [
-            "run-annotators",
+            "run-csv-items",
             "--annotator",
             "demo_annotator",
             str(in_path),

--- a/tests/test_prompt_pipeline.py
+++ b/tests/test_prompt_pipeline.py
@@ -20,7 +20,9 @@ from modelgauge.prompt_pipeline import (
     PromptSutAssigner,
     PromptSutWorkers,
     PromptSink,
+    SutInteraction,
 )
+from modelgauge.sut import SUTCompletion
 from modelgauge.single_turn_prompt_response import PromptWithContext
 from tests.fake_sut import FakeSUT, FakeSUTRequest, FakeSUTResponse
 
@@ -122,7 +124,9 @@ def test_prompt_sut_worker_normal(suts):
     w = PromptSutWorkers(suts)
     result = w.handle_item((prompt_with_context, "fake1"))
 
-    assert result == (prompt_with_context, "fake1", "a response")
+    assert result == SutInteraction(
+        prompt_with_context, "fake1", SUTCompletion(text="a response")
+    )
 
 
 def test_prompt_sut_worker_cache(suts, tmp_path):
@@ -135,11 +139,15 @@ def test_prompt_sut_worker_cache(suts, tmp_path):
 
     w = PromptSutWorkers(suts, cache_path=tmp_path)
     result = w.handle_item((prompt_with_context, "fake1"))
-    assert result == (prompt_with_context, "fake1", "a response")
+    assert result == SutInteraction(
+        prompt_with_context, "fake1", SUTCompletion(text="a response")
+    )
     assert mock.call_count == 1
 
     result = w.handle_item((prompt_with_context, "fake1"))
-    assert result == (prompt_with_context, "fake1", "a response")
+    assert result == SutInteraction(
+        prompt_with_context, "fake1", SUTCompletion(text="a response")
+    )
     assert mock.call_count == 1
 
 

--- a/tests/test_prompt_pipeline.py
+++ b/tests/test_prompt_pipeline.py
@@ -94,6 +94,16 @@ def test_csv_prompt_input(tmp_path):
     assert len(items) == 1
 
 
+@pytest.mark.parametrize("header", ["UID,Extra,Response\n", "Hello,World,Extra\n"])
+def test_csv_prompt_input_invalid_columns(tmp_path, header):
+    file_path = tmp_path / "input.csv"
+    file_path.write_text(header)
+    with pytest.raises(
+        AssertionError, match="Invalid input file. Must have columns: UID, Text."
+    ):
+        CsvPromptInput(file_path)
+
+
 def test_csv_prompt_output(tmp_path, suts):
     file_path = tmp_path / "output.csv"
 
@@ -111,6 +121,15 @@ def test_csv_prompt_output(tmp_path, suts):
         assert items[0]["Text"] == "a"
         assert items[0]["fake1"] == "a1"
         assert items[0]["fake2"] == "a2"
+
+
+@pytest.mark.parametrize("output_fname", ["output.jsonl", "output"])
+def test_csv_prompt_output_invalid(tmp_path, suts, output_fname):
+    file_path = tmp_path / output_fname
+    with pytest.raises(
+        AssertionError, match=f"Invalid output file {file_path}. Must be of type CSV."
+    ):
+        CsvPromptOutput(file_path, suts)
 
 
 def test_prompt_sut_worker_normal(suts):


### PR DESCRIPTION
Merges `run-prompts` and `run-annotators` commands into `run-csv-items`.

- `run-csv-items -s sut_1 -s sut_2 prompts.csv`: Get the suts' responses to the prompts the in the input file. 
    - Input CSV headers: UID, Text
    - Output (CSV) headers: UID, Text, sut_1, sut_2
      - SUT columns contain responses
- `run-csv-items -s sut_1 -s sut_2 -a annotator_1 -a annotator_2 prompts.csv` Get the suts' responses to the prompts and then annotate the prompt + responses.
    - Input CSV headers: UID, Text
    - Output: Same as the output below.
- `run-csv-items -a annotator_1 -a annotator_2 prompt_responses.csv` Get annotations for prompt + responses in the input file.
    - Input CSV headers: UID, Prompt, SUT, Response
    - Output: JSON lines file. Each json object has the form:
        ```
        {
          "UID": ..., "Prompt": ..., "SUT": ..., "Response": ..., 
          "Annotations": {"annotator_1": ..., "annotator_2": ...}
        {
       ```
