### PR TITLE
Remove safetest base class

### DIFF
--- a/modelgauge/tests/safe.py
+++ b/modelgauge/tests/safe.py
@@ -12,22 +12,7 @@ Version 0.5 hazards and tests:
     - ssh: Suicide & Self-Harm
     - hat: Hate
 
-Version 1.0 hazards and tests:
-    NOTE: This version is still a work in progress and subject to change.
-    Tests will closely follow the hazard taxonomy used by Llama Guard 3 (https://huggingface.co/meta-llama/Llama-Guard-3-8B#hazard-taxonomy-and-policy).
-    Test UIDs follow the form "safe-{ hazard acronym }-1.0" (e.g. safe-vcr-1.0). The hazard acronyms are as follows:
-    - vcr: Violent Crimes
-    - ncr: Non-Violent Crimes
-    - src: Sex-Related Crimes
-    - cse: Child Sexual Exploitation
-    - dfm: Defamation
-    - spc: Specialized Advice
-    - prv: Privacy Violations
-    - ipv: Intellection Property Violations
-    - iwp: Indiscriminate Weapons (CBRNE)
-    - hte: Hate
-    - ssh: Suicide & Self-Harm
-    - sxc_prn: Sexual Content; pornographic
+
 """
 
 import csv
@@ -80,6 +65,22 @@ class SafePersonas(str, Enum):
 
 @modelgauge_test(requires_sut_capabilities=[AcceptsTextPrompt])
 class SafeTest(PromptResponseTest):
+    """
+    Version 0.5 of SAFE test.
+
+    Each test instance corresponds to a different hazard.
+    The hazards taxonomy used by this version is described in detail here:
+        https://drive.google.com/file/d/1V8KFfk8awaAXc83nZZzDV2bHgPT8jbJY/view.
+    Test UIDs follow the form "safe-{ hazard acronym }" (e.g. safe-vcr). The hazard acronyms are as follows:
+    - vcr: Violent Crimes
+    - nvc: Non-Violent Crimes
+    - scr: Sex-Related Crimes
+    - cae: Child Sexual Exploitation
+    - cbr: Indiscriminate Weapons (CBRNE)
+    - ssh: Suicide & Self-Harm
+    - hat: Hate
+    """
+
     hazards = ["vcr", "nvc", "scr", "cae", "cbr", "ssh", "hat"]
 
     def __init__(

--- a/modelgauge/tests/safe_v1.py
+++ b/modelgauge/tests/safe_v1.py
@@ -1,46 +1,13 @@
-"""
-Each test registered in this file corresponds to a different hazard in the MLCommons taxonomy of hazards.
-
-Version 0.5 hazards and tests:
-    The hazards taxonomy is described in detail here: https://drive.google.com/file/d/1V8KFfk8awaAXc83nZZzDV2bHgPT8jbJY/view.
-    Test UIDs follow the form "safe-{ hazard acronym }" (e.g. safe-vcr). The hazard acronyms are as follows:
-    - vcr: Violent Crimes
-    - nvc: Non-Violent Crimes
-    - scr: Sex-Related Crimes
-    - cae: Child Sexual Exploitation
-    - cbr: Indiscriminate Weapons (CBRNE)
-    - ssh: Suicide & Self-Harm
-    - hat: Hate
-
-Version 1.0 hazards and tests:
-    NOTE: This version is still a work in progress and subject to change.
-    Tests will closely follow the hazard taxonomy used by Llama Guard 3 (https://huggingface.co/meta-llama/Llama-Guard-3-8B#hazard-taxonomy-and-policy).
-    Test UIDs follow the form "safe-{ hazard acronym }-1.0" (e.g. safe-vcr-1.0). The hazard acronyms are as follows:
-    - vcr: Violent Crimes
-    - ncr: Non-Violent Crimes
-    - src: Sex-Related Crimes
-    - cse: Child Sexual Exploitation
-    - dfm: Defamation
-    - spc: Specialized Advice
-    - prv: Privacy Violations
-    - ipv: Intellection Property Violations
-    - iwp: Indiscriminate Weapons (CBRNE)
-    - hte: Hate
-    - ssh: Suicide & Self-Harm
-    - sxc_prn: Sexual Content; pornographic
-"""
-
 import csv
 from enum import Enum
-from pydantic import BaseModel
-from typing import Dict, List, Mapping
+from typing import List, Mapping, Dict
 
 from modelgauge.aggregations import get_measurement_stats_by_key
 from modelgauge.annotator import Annotator
 from modelgauge.annotators.llama_guard_annotator import (
-    LlamaGuardAnnotation,
-    LlamaGuardAnnotator,
     LlamaGuardVersion,
+    LlamaGuardAnnotator,
+    LlamaGuardAnnotation,
 )
 from modelgauge.base_test import PromptResponseTest
 from modelgauge.dependency_helper import DependencyHelper
@@ -48,53 +15,78 @@ from modelgauge.external_data import ExternalData, WebData
 from modelgauge.prompt import SUTOptions, TextPrompt
 from modelgauge.secret_values import InjectSecret
 from modelgauge.single_turn_prompt_response import (
-    MeasuredTestItem,
-    PromptWithContext,
     TestItem,
+    PromptWithContext,
     TestItemAnnotations,
+    MeasuredTestItem,
 )
 from modelgauge.sut_capabilities import AcceptsTextPrompt
 from modelgauge.suts.together_client import TogetherApiKey
 from modelgauge.test_decorator import modelgauge_test
 from modelgauge.test_registry import TESTS
+from modelgauge.tests.safe import SafeTestItemContext, SafeTestResult, PersonaResult
 
 
-class SafeTestItemContext(BaseModel):
-    persona_type: str
+class Locale(str, Enum):
+    EN_US = "EN_US"  # English, United States
+    FR_FR = "FR_FR"  # French, France
+    ZH_CN = "ZH_CN"  # Simplified Chinese, China
+    HI_IN = "HI_IN"  # Hindi, India
 
 
-class PersonaResult(BaseModel):
-    frac_safe: float
-    num_items: int
-
-
-class SafeTestResult(BaseModel):
-    persona_results: Mapping[str, PersonaResult]
-
-
-class SafePersonas(str, Enum):
-    TYPICAL = "typical"
-    MALICIOUS = "malicious"
-    VULNERABLE = "vulnerable"
+class SafePersonasVersion1(str, Enum):
+    NORMAL = "normal"
+    SKILLED = "skilled"
+    UNSKILLED = "unskilled"
 
 
 @modelgauge_test(requires_sut_capabilities=[AcceptsTextPrompt])
-class SafeTest(PromptResponseTest):
-    hazards = ["vcr", "nvc", "scr", "cae", "cbr", "ssh", "hat"]
+class SafeTestVersion1(PromptResponseTest):
+    """Version 1.0 of SAFE test.
+
+    Assumptions about working group deliverables:
+    - Prompt files:
+        - Filename format:
+            safe-[hazard uid]-[timestamp]-[supplier code].csv
+        - CSV files include columns:
+            Prompt UID, Text, Hazard UID, Locale, Persona
+        - There many be multiple personas and locales in one file.
+        - There is only one hazard per file.
+        - There may be multiple files associated with each hazard.
+          These files differ by supplier and have no overlap in prompts.
+    - One hazard per test.
+    - One locale per test.
+    - Tests can have multiple personas (not 100% certain about this).
+    """
+
+    hazards = [
+        "vcr",
+        "ncr",
+        "src",
+        "cse",
+        "dfm",
+        "spc",
+        "prv",
+        "ipv",
+        "iwp",
+        "hte",
+        "ssh",
+        "sxc",
+    ]
 
     def __init__(
         self,
         uid: str,
         hazard: str,
-        folder_name: str,
+        locale: Locale,
         together_api_key: TogetherApiKey,
-        persona_types: List[SafePersonas],
+        persona_types: List[SafePersonasVersion1],
         llama_guard_version: LlamaGuardVersion = LlamaGuardVersion.VERSION_2,
     ):
         super().__init__(uid)
         assert hazard in self.hazards, f"Invalid hazard type {hazard}."
         self.hazard = hazard
-        self.folder_name = folder_name
+        self.locale = locale
         self.together_api_key = together_api_key
         assert len(persona_types), "At least one persona type must be specified."
         assert len(set(persona_types)) == len(
@@ -103,17 +95,19 @@ class SafeTest(PromptResponseTest):
         self.persona_types = persona_types
         self.llama_guard_version = llama_guard_version
 
-    def _persona_dependency_key(self, persona: SafePersonas) -> str:
-        return f"{self.folder_name}_{self.hazard}_{persona.value}"
+    def _get_prompt_set_names(self):
+        # TODO: Get all filenames with this test's hazard from modellab.
+        return [f"safe-{self.hazard}-20240801-FAKE"]
 
     def get_dependencies(self) -> Mapping[str, ExternalData]:
         modellab_base_download_url = (
             "https://ai-safety-dev.uc.r.appspot.com/files/download"
         )
         dependencies = {}
-        for persona in self.persona_types:
-            dependencies[self._persona_dependency_key(persona)] = WebData(
-                source_url=f"{modellab_base_download_url}/mls_ais_wg_safe_{self.hazard}_{persona.value}-user.csv",
+        for prompt_set in self._get_prompt_set_names():
+            # TODO: Ask modellab for a stable version.
+            dependencies[prompt_set] = WebData(
+                source_url=f"{modellab_base_download_url}/{prompt_set}.csv"
             )
         return dependencies
 
@@ -123,23 +117,30 @@ class SafeTest(PromptResponseTest):
             temperature=0.01,
         )
         test_items: List[TestItem] = []
-        for persona in self.persona_types:
-            data_file = dependency_helper.get_local_path(
-                self._persona_dependency_key(persona)
-            )
+        for prompt_set in self._get_prompt_set_names():
+            data_file = dependency_helper.get_local_path(prompt_set)
             with open(data_file, "r") as csvfile:
                 reader = csv.DictReader(csvfile)
                 for row in reader:
-                    text = row["Prompt"].strip()
+                    text = row["Text"].strip()
                     if not text:
                         continue
-                    file_hazard = row["Hazard category shorthand"]
+
+                    # Check that prompt is for correct hazard/persona/locale.
+                    file_hazard = row["Hazard UID"]
+                    persona = SafePersonasVersion1(row["Persona"])
+                    locale = Locale(row["Locale"])
                     assert (
                         file_hazard == self.hazard
                     ), f"Expected {data_file} to have {self.hazard}, but had {file_hazard}."
+                    if persona not in self.persona_types:
+                        continue
+                    if locale != self.locale:
+                        continue
+
                     prompt = PromptWithContext(
                         prompt=TextPrompt(text=text, options=sut_options),
-                        source_id=row["UID"],
+                        source_id=row["Prompt UID"],
                     )
                     test_items.append(
                         TestItem(
@@ -184,62 +185,16 @@ class SafeTest(PromptResponseTest):
         return SafeTestResult(persona_results=persona_results)
 
 
-FOLDER_NAME = "data_04apr2024"
 API_KEY_SECRET = InjectSecret(TogetherApiKey)
 
+# TODO: Remove version number from 1.0 UIDs.
+#  Will need to consider how to handle hazard acronyms that are shared between v0.5 and v1.0 (e.g. safe-vcr).
+#  This will likely involve some sort of versioning mechanism in the test registry.
 TESTS.register(
-    SafeTest,
-    "safe-cae",
-    "cae",
-    FOLDER_NAME,
+    SafeTestVersion1,
+    "safe-dfm-1.0",
+    "dfm",
+    Locale.EN_US,
     API_KEY_SECRET,
-    persona_types=[SafePersonas.TYPICAL, SafePersonas.MALICIOUS],
-)
-TESTS.register(
-    SafeTest,
-    "safe-cbr",
-    "cbr",
-    FOLDER_NAME,
-    API_KEY_SECRET,
-    persona_types=[SafePersonas.TYPICAL, SafePersonas.MALICIOUS],
-)
-TESTS.register(
-    SafeTest,
-    "safe-hat",
-    "hat",
-    FOLDER_NAME,
-    API_KEY_SECRET,
-    persona_types=[SafePersonas.TYPICAL, SafePersonas.MALICIOUS],
-)
-TESTS.register(
-    SafeTest,
-    "safe-nvc",
-    "nvc",
-    FOLDER_NAME,
-    API_KEY_SECRET,
-    persona_types=[SafePersonas.TYPICAL, SafePersonas.MALICIOUS],
-)
-TESTS.register(
-    SafeTest,
-    "safe-scr",
-    "scr",
-    FOLDER_NAME,
-    API_KEY_SECRET,
-    persona_types=[SafePersonas.TYPICAL, SafePersonas.MALICIOUS],
-)
-TESTS.register(
-    SafeTest,
-    "safe-ssh",
-    "ssh",
-    FOLDER_NAME,
-    API_KEY_SECRET,
-    persona_types=[SafePersonas.TYPICAL, SafePersonas.VULNERABLE],
-)
-TESTS.register(
-    SafeTest,
-    "safe-vcr",
-    "vcr",
-    FOLDER_NAME,
-    API_KEY_SECRET,
-    persona_types=[SafePersonas.TYPICAL, SafePersonas.MALICIOUS],
+    persona_types=[SafePersonasVersion1.NORMAL],
 )

--- a/modelgauge/tests/safe_v1.py
+++ b/modelgauge/tests/safe_v1.py
@@ -42,7 +42,7 @@ class SafePersonasVersion1(str, Enum):
 
 @modelgauge_test(requires_sut_capabilities=[AcceptsTextPrompt])
 class SafeTestVersion1(PromptResponseTest):
-    """Version 1.0 of SAFE test.
+    """Version 1.0 of SAFE test. This version is still a work in progress and subject to change.
 
     Assumptions about working group deliverables:
     - Prompt files:
@@ -57,6 +57,21 @@ class SafeTestVersion1(PromptResponseTest):
     - One hazard per test.
     - One locale per test.
     - Tests can have multiple personas (not 100% certain about this).
+
+    Tests will closely follow the hazard taxonomy used by Llama Guard 3 (https://huggingface.co/meta-llama/Llama-Guard-3-8B#hazard-taxonomy-and-policy).
+    Test UIDs follow the form "safe-{ hazard acronym }-1.0" (e.g. safe-vcr-1.0). The hazard acronyms are as follows:
+    - vcr: Violent Crimes
+    - ncr: Non-Violent Crimes
+    - src: Sex-Related Crimes
+    - cse: Child Sexual Exploitation
+    - dfm: Defamation
+    - spc: Specialized Advice
+    - prv: Privacy Violations
+    - ipv: Intellection Property Violations
+    - iwp: Indiscriminate Weapons (CBRNE)
+    - hte: Hate
+    - ssh: Suicide & Self-Harm
+    - sxc_prn: Sexual Content; pornographic
     """
 
     hazards = [


### PR DESCRIPTION
This PR re-organizes SafeTest's versions.  This is motivated by my experience last week in attempting to update SafeTest v1.0 with a new annotator for the demo. The rigidity of sharing a `SafeTestBase` parent made it much more difficult to update an individual test version. Plus I realized that the two versions will actually end up having very little in common, so we do not gain much from the base class.
So I would like to de-tangle the two versions from one another in preparation for a more elegant annotator integration this week.