### PR TITLE
Adding 'system' role to openai_client _ROLE_MAP

### DIFF
--- a/plugins/openai/modelgauge/suts/openai_client.py
+++ b/plugins/openai/modelgauge/suts/openai_client.py
@@ -32,6 +32,7 @@ _TOOL_ROLE = "tool_call_id"
 _ROLE_MAP = {
     ChatRole.user: _USER_ROLE,
     ChatRole.sut: _ASSISTANT_ROLE,
+    ChatRole.system: _SYSTEM_ROLE,
 }
 
 


### PR DESCRIPTION
The OpenAI client SUT under plugins Role_map currently only has User and Assistant roles defined. Using system prompts for OpenAI GPT models require the 'system role'. 