### PR TITLE
Keep track of items that can't be processed

### DIFF
--- a/modelgauge/general.py
+++ b/modelgauge/general.py
@@ -85,3 +85,7 @@ def get_class(module_name: str, qual_name: str):
 def current_local_datetime():
     """Get the current local date time, with timezone."""
     return datetime.datetime.now().astimezone()
+
+
+class TestItemError(Exception):
+    """Error encountered while processing a test item"""

--- a/modelgauge/records.py
+++ b/modelgauge/records.py
@@ -21,6 +21,16 @@ class TestItemRecord(BaseModel):
     __test__ = False
 
 
+class TestItemExceptionRecord(BaseModel):
+    """Record of all data relevant to a single TestItem."""
+
+    test_item: TestItem
+    error_message: str
+    cause: str
+
+    __test__ = False
+
+
 class TestRecord(BaseModel):
     """Record of all data relevant to a single run of a Test."""
 
@@ -33,6 +43,7 @@ class TestRecord(BaseModel):
     # TODO We should either reintroduce "Turns" here, or expect
     # there to b different schemas for different TestImplementationClasses.
     test_item_records: List[TestItemRecord]
+    test_item_exceptions: List[TestItemExceptionRecord]
     result: TestResult
 
     __test__ = False

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -80,6 +80,7 @@ def test_serialize_test_record():
                 measurements={"m1": 1.0},
             )
         ],
+        test_item_exceptions=[],
         result=TestResult.from_instance(MockResult(mock_result=2.0)),
     )
 
@@ -198,6 +199,7 @@ def test_serialize_test_record():
       }
     }
   ],
+  "test_item_exceptions": [],
   "result": {
     "module": "tests.test_records",
     "class_name": "MockResult",


### PR DESCRIPTION
- Execution continues if a SUT or annotator raises an exception while processing a test item.
- A list of the unprocessed test items + their errors is included in the JSON report.