### PR TITLE
mypy is complaining about untyped imports

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/modelgauge/annotators/llama_guard_annotator.py
+++ b/modelgauge/annotators/llama_guard_annotator.py
@@ -343,7 +343,7 @@ ANNOTATORS.register(
 
 if __name__ == "__main__":
     import sys
-    from modelgauge.config import load_secrets_from_config
+    from modelgauge.config import load_secrets_from_config # type: ignore
     from modelgauge.prompt import TextPrompt
 
     secrets = load_secrets_from_config()

--- a/modelgauge/tests/safe_v1.py
+++ b/modelgauge/tests/safe_v1.py
@@ -5,58 +5,42 @@ from typing import Dict, List, Mapping, Optional
 
 from modelgauge.aggregations import get_measurement_stats_by_key
 from modelgauge.annotator import Annotator
-from modelgauge.annotators.llama_guard_annotator import (
-    LlamaGuardAnnotation,
-    LlamaGuardAnnotator,
-    LlamaGuardVersion,
-)
+from modelgauge.annotators.llama_guard_annotator import (LlamaGuardAnnotation,
+                                                         LlamaGuardAnnotator,
+                                                         LlamaGuardVersion)
 from modelgauge.base_test import PromptResponseTest
 from modelgauge.dependency_helper import DependencyHelper
 from modelgauge.external_data import ExternalData, WebData
 from modelgauge.prompt import SUTOptions, TextPrompt
-from modelgauge.secret_values import InjectSecret, RequiredSecret, SecretDescription
-from modelgauge.single_turn_prompt_response import (
-    MeasuredTestItem,
-    PromptWithContext,
-    TestItem,
-    TestItemAnnotations,
-)
+from modelgauge.secret_values import (InjectSecret, RequiredSecret,
+                                      SecretDescription)
+from modelgauge.single_turn_prompt_response import (MeasuredTestItem,
+                                                    PromptWithContext,
+                                                    TestItem,
+                                                    TestItemAnnotations)
 from modelgauge.sut_capabilities import AcceptsTextPrompt
 from modelgauge.suts.together_client import TogetherApiKey
 from modelgauge.test_decorator import modelgauge_test
 from modelgauge.test_registry import TESTS
-from modelgauge.tests.safe import PersonaResult, SafeTestItemContext, SafeTestResult
+from modelgauge.tests.safe import (PersonaResult, SafeTestItemContext,
+                                   SafeTestResult)
 
 try:
-    from modelgauge.annotators.ensemble_annotator import (
-        EnsembleAnnotator,
-    )  # type: ignore
-    from modelgauge.annotators.llama_3_70b_chat_annotator import (
-        LLAMA_3_70B_CONFIG,
-    )  # type: ignore
-    from modelgauge.annotators.llama_guard_2_lora_annotator import (
-        LlamaGuard2LoRAAnnotator,
-    )  # type: ignore
-    from modelgauge.annotators.llama_guard_2_lora_annotator import (
-        LlamaGuard2LoRAConfig,
-    )  # type: ignore; type: ignore
-    from modelgauge.annotators.local_lg2_lora_annotator import (
-        config as LG2_LORA_CONFIG,
-    )  # type: ignore
-    from modelgauge.annotators.mistral_8x22b_instruct_annotator import (
-        MISTRAL_8x22B_CONFIG,
-    )  # type: ignore; type: ignore
-    from modelgauge.annotators.prompt_engineered_annotator import (
-        PromptEngineeredAnnotator,
-    )  # type: ignore; type: ignore
-    from modelgauge.annotators.wildguard_annotator import (
-        WildguardAnnotator,
-    )  # type: ignore
-    from modelgauge.annotators.wildguard_annotator import (
-        WILDGUARD_ANNOTATOR_CONFIG,
-    )  # type: ignore
+    # fmt: off
+    # mypy will error out if # type: ignore isn't at the end of the physical line where
+    # the imported module is listed, not the logical parsed line. So a linter/formatter
+    # may break mypy validation :(
+    from modelgauge.annotators.ensemble_annotator import EnsembleAnnotator  # type: ignore
+    from modelgauge.annotators.llama_3_70b_chat_annotator import LLAMA_3_70B_CONFIG  # type: ignore
+    from modelgauge.annotators.llama_guard_2_lora_annotator import LlamaGuard2LoRAAnnotator # type: ignore
+    from modelgauge.annotators.local_lg2_lora_annotator import config as LG2_LORA_CONFIG  # type: ignore
+    from modelgauge.annotators.mistral_8x22b_instruct_annotator import MISTRAL_8x22B_CONFIG  # type: ignore
+    from modelgauge.annotators.prompt_engineered_annotator import PromptEngineeredAnnotator  # type: ignore
+    from modelgauge.annotators.wildguard_annotator import WILDGUARD_ANNOTATOR_CONFIG # type: ignore
+    from modelgauge.annotators.wildguard_annotator import  WildguardAnnotator  # type: ignore
     from modelgauge.safety_model_response import SafetyModelResponse  # type: ignore
 
+    # fmt: on
     PRIVATE_ANNOTATORS_AVAILABLE = True
 except ImportError:
     PRIVATE_ANNOTATORS_AVAILABLE = False

--- a/modelgauge/tests/safe_v1.py
+++ b/modelgauge/tests/safe_v1.py
@@ -14,41 +14,47 @@ from modelgauge.base_test import PromptResponseTest
 from modelgauge.dependency_helper import DependencyHelper
 from modelgauge.external_data import ExternalData, WebData
 from modelgauge.prompt import SUTOptions, TextPrompt
-from modelgauge.secret_values import (
-    InjectSecret,
-    RequiredSecret,
-    SecretDescription,
-)
+from modelgauge.secret_values import InjectSecret, RequiredSecret, SecretDescription
 from modelgauge.single_turn_prompt_response import (
-    TestItem,
-    PromptWithContext,
-    TestItemAnnotations,
     MeasuredTestItem,
+    PromptWithContext,
+    TestItem,
+    TestItemAnnotations,
 )
 from modelgauge.sut_capabilities import AcceptsTextPrompt
 from modelgauge.suts.together_client import TogetherApiKey
 from modelgauge.test_decorator import modelgauge_test
 from modelgauge.test_registry import TESTS
-from modelgauge.tests.safe import SafeTestItemContext, SafeTestResult, PersonaResult
+from modelgauge.tests.safe import PersonaResult, SafeTestItemContext, SafeTestResult
 
 try:
-    from modelgauge.annotators.ensemble_annotator import EnsembleAnnotator  # type: ignore
-    from modelgauge.annotators.llama_guard_2_lora_annotator import (  # type: ignore
-        LlamaGuard2LoRAAnnotator,  # type: ignore
-        LlamaGuard2LoRAConfig,  # type: ignore
-    )
-    from modelgauge.annotators.llama_3_70b_chat_annotator import LLAMA_3_70B_CONFIG  # type: ignore
-    from modelgauge.annotators.local_lg2_lora_annotator import config as LG2_LORA_CONFIG  # type: ignore
-    from modelgauge.annotators.mistral_8x22b_instruct_annotator import (  # type: ignore
-        MISTRAL_8x22B_CONFIG,  # type: ignore
-    )
-    from modelgauge.annotators.prompt_engineered_annotator import (  # type: ignore
-        PromptEngineeredAnnotator,  # type: ignore
-    )
-    from modelgauge.annotators.wildguard_annotator import (  # type: ignore
-        WildguardAnnotator,  # type: ignore
+    from modelgauge.annotators.ensemble_annotator import (
+        EnsembleAnnotator,
+    )  # type: ignore
+    from modelgauge.annotators.llama_3_70b_chat_annotator import (
+        LLAMA_3_70B_CONFIG,
+    )  # type: ignore
+    from modelgauge.annotators.llama_guard_2_lora_annotator import (
+        LlamaGuard2LoRAAnnotator,
+    )  # type: ignore
+    from modelgauge.annotators.llama_guard_2_lora_annotator import (
+        LlamaGuard2LoRAConfig,
+    )  # type: ignore; type: ignore
+    from modelgauge.annotators.local_lg2_lora_annotator import (
+        config as LG2_LORA_CONFIG,
+    )  # type: ignore
+    from modelgauge.annotators.mistral_8x22b_instruct_annotator import (
+        MISTRAL_8x22B_CONFIG,
+    )  # type: ignore; type: ignore
+    from modelgauge.annotators.prompt_engineered_annotator import (
+        PromptEngineeredAnnotator,
+    )  # type: ignore; type: ignore
+    from modelgauge.annotators.wildguard_annotator import (
+        WildguardAnnotator,
+    )  # type: ignore
+    from modelgauge.annotators.wildguard_annotator import (
         WILDGUARD_ANNOTATOR_CONFIG,
-    )
+    )  # type: ignore
     from modelgauge.safety_model_response import SafetyModelResponse  # type: ignore
 
     PRIVATE_ANNOTATORS_AVAILABLE = True
@@ -167,9 +173,9 @@ class SafeTestVersion1(PromptResponseTest):
         # will be replaced by secrets loaded from a secret config.
         self.together_api_key = together_api_key
         if self.use_private_annotators:
-            self._configure_vllm_annotators(vllm_api_key)
-            self._configure_huggingface_annotators(huggingface_key)
-            self._configure_together_annotators(together_api_key)
+            self._configure_vllm_annotators(vllm_api_key)  # type: ignore
+            self._configure_huggingface_annotators(huggingface_key)  # type: ignore
+            self._configure_together_annotators(together_api_key)  # type: ignore
 
     # TODO: Encapsulate multipart secrets (e.g. key and URL).
     # I'm not convinced the SafeTestV1 class needs to concern itself


### PR DESCRIPTION
We don't want to disable checks for untyped imports project-wide, I think. The way to achieve that is to use the `# type: ignore` comment (the way Barbara had it), but a round of linting and black formatting reformatted the private annotator import lines. That moved the type ignore comment to the end of the parsed line, rather than the end of the "physical" line in the file, and mypy doesn't understand the comment if it's there. 

:(