### PR TITLE
mypy is a little overzealous

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/modelgauge/tests/safe_v1.py
+++ b/modelgauge/tests/safe_v1.py
@@ -167,8 +167,8 @@ class SafeTestVersion1(PromptResponseTest):
         # will be replaced by secrets loaded from a secret config.
         self.together_api_key = together_api_key
         if self.use_private_annotators:
-            self._configure_vllm_annotators(vllm_api_key)
-            self._configure_huggingface_annotators(huggingface_key)
+            self._configure_vllm_annotators(vllm_api_key)  # type: ignore
+            self._configure_huggingface_annotators(huggingface_key)  # type: ignore
             self._configure_together_annotators(together_api_key)
 
     # TODO: Encapsulate multipart secrets (e.g. key and URL).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,11 @@ addopts="--ignore=modelgauge/ --ignore=demo_plugin/modelgauge/ --ignore=plugins/
 explicit_package_bases = true
 mypy_path = "., demo_plugin, plugins/standard_tests, plugins/openai, plugins/huggingface, plugins/perspective_api"
 
+[[tool.mypy.overrides]]
+module = "modelgauge.tests.*,modelgauge.annotators.*,modelgauge.safety_model_response,plugins.*"
+ignore_missing_imports = true
+
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Some formatters (e.g. isort) move mypy's `# type: ignore` comment to the end of the parsed line. mypy only understands it if it's at the end of the line in the file. :( 