### PR TITLE
Refactor: encapsulate annotators used in safe tests

### DIFF
--- a/modelgauge/annotator_set.py
+++ b/modelgauge/annotator_set.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+
+
+class AnnotatorSet(ABC):
+    @property
+    def configuration(self):
+        raise NotImplementedError
+
+    @property
+    def annotators(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def configure(self):
+        pass
+
+    @abstractmethod
+    def evaluate(self, *args, **kwargs):
+        pass

--- a/modelgauge/annotator_set.py
+++ b/modelgauge/annotator_set.py
@@ -3,16 +3,12 @@ from abc import ABC, abstractmethod
 
 class AnnotatorSet(ABC):
     @property
-    def configuration(self):
-        raise NotImplementedError
-
-    @property
     def annotators(self):
         raise NotImplementedError
 
-    @abstractmethod
-    def configure(self):
-        pass
+    @property
+    def secrets(self):
+        raise NotImplementedError
 
     @abstractmethod
     def evaluate(self, *args, **kwargs):

--- a/modelgauge/default_annotator_set.py
+++ b/modelgauge/default_annotator_set.py
@@ -1,0 +1,46 @@
+from typing import Dict
+
+from modelgauge.annotator_set import AnnotatorSet
+from modelgauge.annotators.llama_guard_annotator import (
+    LlamaGuardAnnotation,
+    LlamaGuardAnnotator,
+    LlamaGuardVersion,
+)
+from modelgauge.config import load_secrets_from_config
+from modelgauge.single_turn_prompt_response import (
+    TestItemAnnotations,
+)
+from modelgauge.suts.together_client import TogetherApiKey
+
+
+ANNOTATOR_NAME = "llama_guard_2"
+
+
+class DefaultAnnotatorSet(AnnotatorSet):
+
+    annotators = {}
+    configuration = {}
+
+    # TODO all these should be static
+    def configure(self):
+        self.__load_secrets()
+        self._load_annotators()
+
+    def __load_secrets(self):
+        secrets = load_secrets_from_config()
+        self.configuration["together_api_key"] = TogetherApiKey.make(secrets)
+
+    def _load_annotators(self):
+        self.annotators[ANNOTATOR_NAME] = LlamaGuardAnnotator(
+            ANNOTATOR_NAME,
+            self.configuration["together_api_key"],
+            llama_guard_version=LlamaGuardVersion.VERSION_2,
+        )
+
+    def evaluate(self, item: TestItemAnnotations) -> Dict[str, float]:
+        annotation = (
+            item.interactions[0]
+            .response.completions[0]
+            .get_annotation(ANNOTATOR_NAME, LlamaGuardAnnotation)
+        )
+        return {"is_safe": float(annotation.is_safe)}

--- a/modelgauge/default_annotator_set.py
+++ b/modelgauge/default_annotator_set.py
@@ -1,5 +1,6 @@
-from typing import Dict
+from typing import Dict, Any
 
+from modelgauge.annotator import Annotator
 from modelgauge.annotator_set import AnnotatorSet
 from modelgauge.annotators.llama_guard_annotator import (
     LlamaGuardAnnotation,
@@ -18,8 +19,8 @@ ANNOTATOR_NAME = "llama_guard_2"
 
 class DefaultAnnotatorSet(AnnotatorSet):
 
-    annotators = {}
-    configuration = {}
+    annotators: dict[str, Annotator] = {}
+    configuration: dict[str, Any] = {}
 
     # TODO all these should be static
     def configure(self):

--- a/modelgauge/default_annotator_set.py
+++ b/modelgauge/default_annotator_set.py
@@ -7,11 +7,11 @@ from modelgauge.annotators.llama_guard_annotator import (
     LlamaGuardAnnotator,
     LlamaGuardVersion,
 )
-from modelgauge.config import load_secrets_from_config
 from modelgauge.single_turn_prompt_response import (
     TestItemAnnotations,
 )
 from modelgauge.suts.together_client import TogetherApiKey
+from modelgauge.secret_values import InjectSecret
 
 
 ANNOTATOR_NAME = "llama_guard_2"
@@ -22,14 +22,15 @@ class DefaultAnnotatorSet(AnnotatorSet):
     annotators: dict[str, Annotator] = {}
     configuration: dict[str, Any] = {}
 
-    # TODO all these should be static
+    def __init__(self):
+        self.configure()
+
     def configure(self):
         self.__load_secrets()
         self._load_annotators()
 
     def __load_secrets(self):
-        secrets = load_secrets_from_config()
-        self.configuration["together_api_key"] = TogetherApiKey.make(secrets)
+        self.configuration["together_api_key"] = InjectSecret(TogetherApiKey)
 
     def _load_annotators(self):
         self.annotators[ANNOTATOR_NAME] = LlamaGuardAnnotator(

--- a/modelgauge/private_ensemble_annotator_set.py
+++ b/modelgauge/private_ensemble_annotator_set.py
@@ -1,6 +1,7 @@
 import os
-from typing import Dict
+from typing import Dict, Any
 
+from modelgauge.annotator import Annotator
 from modelgauge.annotator_set import AnnotatorSet
 from modelgauge.config import load_secrets_from_config
 from modelgauge.secret_values import RequiredSecret, SecretDescription
@@ -16,16 +17,16 @@ try:
     )  # type: ignore
     from modelgauge.annotators.llama_guard_2_lora_annotator import (
         LlamaGuard2LoRAAnnotator,
-    )  # type: ignore; type: ignore
+    )  # type: ignore
     from modelgauge.annotators.local_lg2_lora_annotator import (
         config as LG2_LORA_CONFIG,
     )  # type: ignore
     from modelgauge.annotators.mistral_8x22b_instruct_annotator import (
         MISTRAL_8x22B_CONFIG,
-    )  # type: ignore; type: ignore
+    )  # type: ignore
     from modelgauge.annotators.prompt_engineered_annotator import (
         PromptEngineeredAnnotator,
-    )  # type: ignore; type: ignore
+    )  # type: ignore
     from modelgauge.annotators.wildguard_annotator import (  # type: ignore
         WILDGUARD_ANNOTATOR_CONFIG,
         WildguardAnnotator,
@@ -59,8 +60,8 @@ class HuggingFaceKey(RequiredSecret):
 
 class EnsembleAnnotatorSet(AnnotatorSet):
 
-    annotators = {}
-    configuration = {}
+    annotators: dict[str, Annotator] = {}
+    configuration: dict[str, Any] = {}
 
     def configure(self):
         self.__load_secrets()

--- a/modelgauge/private_ensemble_annotator_set.py
+++ b/modelgauge/private_ensemble_annotator_set.py
@@ -3,31 +3,32 @@ from typing import Dict
 
 from modelgauge.annotator_set import AnnotatorSet
 from modelgauge.config import load_secrets_from_config
-from modelgauge.secret_values import (
-    RequiredSecret,
-    SecretDescription,
-)
-from modelgauge.single_turn_prompt_response import (
-    TestItemAnnotations,
-)
+from modelgauge.secret_values import RequiredSecret, SecretDescription
+from modelgauge.single_turn_prompt_response import TestItemAnnotations
 from modelgauge.suts.together_client import TogetherApiKey
 
 try:
-    from modelgauge.annotators.ensemble_annotator import EnsembleAnnotator  # type: ignore
-    from modelgauge.annotators.llama_guard_2_lora_annotator import (  # type: ignore
-        LlamaGuard2LoRAAnnotator,  # type: ignore
-    )
-    from modelgauge.annotators.llama_3_70b_chat_annotator import LLAMA_3_70B_CONFIG  # type: ignore
-    from modelgauge.annotators.local_lg2_lora_annotator import config as LG2_LORA_CONFIG  # type: ignore
-    from modelgauge.annotators.mistral_8x22b_instruct_annotator import (  # type: ignore
-        MISTRAL_8x22B_CONFIG,  # type: ignore
-    )
-    from modelgauge.annotators.prompt_engineered_annotator import (  # type: ignore
-        PromptEngineeredAnnotator,  # type: ignore
-    )
+    from modelgauge.annotators.ensemble_annotator import (
+        EnsembleAnnotator,
+    )  # type: ignore
+    from modelgauge.annotators.llama_3_70b_chat_annotator import (
+        LLAMA_3_70B_CONFIG,
+    )  # type: ignore
+    from modelgauge.annotators.llama_guard_2_lora_annotator import (
+        LlamaGuard2LoRAAnnotator,
+    )  # type: ignore; type: ignore
+    from modelgauge.annotators.local_lg2_lora_annotator import (
+        config as LG2_LORA_CONFIG,
+    )  # type: ignore
+    from modelgauge.annotators.mistral_8x22b_instruct_annotator import (
+        MISTRAL_8x22B_CONFIG,
+    )  # type: ignore; type: ignore
+    from modelgauge.annotators.prompt_engineered_annotator import (
+        PromptEngineeredAnnotator,
+    )  # type: ignore; type: ignore
     from modelgauge.annotators.wildguard_annotator import (  # type: ignore
-        WildguardAnnotator,  # type: ignore
         WILDGUARD_ANNOTATOR_CONFIG,
+        WildguardAnnotator,
     )
     from modelgauge.safety_model_response import SafetyModelResponse  # type: ignore
 except:
@@ -71,17 +72,17 @@ class EnsembleAnnotatorSet(AnnotatorSet):
     def _load_annotators(self):
         self.annotators = {
             MISTRAL_8x22B_CONFIG.name: PromptEngineeredAnnotator(
-                MISTRAL_8x22B_CONFIG.name, MISTRAL_8x22B_CONFIG
+                uid=MISTRAL_8x22B_CONFIG.name, config=MISTRAL_8x22B_CONFIG
             ),
             LLAMA_3_70B_CONFIG.name: PromptEngineeredAnnotator(
-                LLAMA_3_70B_CONFIG.name, LLAMA_3_70B_CONFIG
+                uid=LLAMA_3_70B_CONFIG.name, config=LLAMA_3_70B_CONFIG
             ),
             LG2_LORA_CONFIG.name: LlamaGuard2LoRAAnnotator(
-                LG2_LORA_CONFIG.name, LG2_LORA_CONFIG
+                uid=LG2_LORA_CONFIG.name, config=LG2_LORA_CONFIG
             ),
             WILDGUARD_ANNOTATOR_CONFIG.name: WildguardAnnotator(
-                WILDGUARD_ANNOTATOR_CONFIG.name,
-                WILDGUARD_ANNOTATOR_CONFIG,
+                uid=WILDGUARD_ANNOTATOR_CONFIG.name,
+                config=WILDGUARD_ANNOTATOR_CONFIG,
             ),
         }
 

--- a/modelgauge/private_ensemble_annotator_set.py
+++ b/modelgauge/private_ensemble_annotator_set.py
@@ -79,10 +79,10 @@ class EnsembleAnnotatorSet(AnnotatorSet):
             LG2_LORA_CONFIG.name: LlamaGuard2LoRAAnnotator(
                 LG2_LORA_CONFIG.name, LG2_LORA_CONFIG
             ),
-            # WILDGUARD_ANNOTATOR_CONFIG.name: WildguardAnnotator(
-            #     WILDGUARD_ANNOTATOR_CONFIG.name,
-            #     WILDGUARD_ANNOTATOR_CONFIG,
-            # ),
+            WILDGUARD_ANNOTATOR_CONFIG.name: WildguardAnnotator(
+                WILDGUARD_ANNOTATOR_CONFIG.name,
+                WILDGUARD_ANNOTATOR_CONFIG,
+            ),
         }
 
     def __load_secrets(self):

--- a/modelgauge/private_ensemble_annotator_set.py
+++ b/modelgauge/private_ensemble_annotator_set.py
@@ -1,0 +1,133 @@
+import os
+from typing import Dict
+
+from modelgauge.annotator_set import AnnotatorSet
+from modelgauge.config import load_secrets_from_config
+from modelgauge.secret_values import (
+    RequiredSecret,
+    SecretDescription,
+)
+from modelgauge.single_turn_prompt_response import (
+    TestItemAnnotations,
+)
+from modelgauge.suts.together_client import TogetherApiKey
+
+try:
+    from modelgauge.annotators.ensemble_annotator import EnsembleAnnotator  # type: ignore
+    from modelgauge.annotators.llama_guard_2_lora_annotator import (  # type: ignore
+        LlamaGuard2LoRAAnnotator,  # type: ignore
+    )
+    from modelgauge.annotators.llama_3_70b_chat_annotator import LLAMA_3_70B_CONFIG  # type: ignore
+    from modelgauge.annotators.local_lg2_lora_annotator import config as LG2_LORA_CONFIG  # type: ignore
+    from modelgauge.annotators.mistral_8x22b_instruct_annotator import (  # type: ignore
+        MISTRAL_8x22B_CONFIG,  # type: ignore
+    )
+    from modelgauge.annotators.prompt_engineered_annotator import (  # type: ignore
+        PromptEngineeredAnnotator,  # type: ignore
+    )
+    from modelgauge.annotators.wildguard_annotator import (  # type: ignore
+        WildguardAnnotator,  # type: ignore
+        WILDGUARD_ANNOTATOR_CONFIG,
+    )
+    from modelgauge.safety_model_response import SafetyModelResponse  # type: ignore
+except:
+    raise NotImplementedError("Private annotators are not available.")
+
+
+# TODO: move this out into private repo
+class VllmApiKey(RequiredSecret):
+    @classmethod
+    def description(cls) -> SecretDescription:
+        return SecretDescription(
+            scope="vllm",
+            key="api_key",
+            instructions="Contact MLCommons admin for access.",
+        )
+
+
+# TODO: move this out into private repo
+class HuggingFaceKey(RequiredSecret):
+    @classmethod
+    def description(cls) -> SecretDescription:
+        return SecretDescription(
+            scope="huggingface",
+            key="api_key",
+            instructions="Add your HuggingFace token to secrets, or contact MLCommons admin.",
+        )
+
+
+class EnsembleAnnotatorSet(AnnotatorSet):
+
+    annotators = {}
+    configuration = {}
+
+    def configure(self):
+        self.__load_secrets()
+        self.__configure_vllm_annotators()
+        self.__configure_huggingface_annotators()
+        self.__configure_together_annotators()
+        self._load_annotators()
+
+    def _load_annotators(self):
+        self.annotators = {
+            MISTRAL_8x22B_CONFIG.name: PromptEngineeredAnnotator(
+                MISTRAL_8x22B_CONFIG.name, MISTRAL_8x22B_CONFIG
+            ),
+            LLAMA_3_70B_CONFIG.name: PromptEngineeredAnnotator(
+                LLAMA_3_70B_CONFIG.name, LLAMA_3_70B_CONFIG
+            ),
+            LG2_LORA_CONFIG.name: LlamaGuard2LoRAAnnotator(
+                LG2_LORA_CONFIG.name, LG2_LORA_CONFIG
+            ),
+            # WILDGUARD_ANNOTATOR_CONFIG.name: WildguardAnnotator(
+            #     WILDGUARD_ANNOTATOR_CONFIG.name,
+            #     WILDGUARD_ANNOTATOR_CONFIG,
+            # ),
+        }
+
+    def __load_secrets(self):
+        secrets = load_secrets_from_config()
+        self.configuration["together_api_key"] = TogetherApiKey.make(secrets)
+        self.configuration["huggingface_key"] = HuggingFaceKey.make(secrets)
+        self.configuration["vllm_api_key"] = VllmApiKey.make(secrets)
+        # TODO: maybe put the requirements into a self.requires dict to handle this declaratively?
+        assert self.configuration[
+            "together_api_key"
+        ], "Together API key is required for this annotator set."
+        assert self.configuration[
+            "huggingface_key"
+        ], "Huggingface token is required for this annotator set."
+        assert self.configuration[
+            "vllm_api_key"
+        ], "VLLM API key is required for this annotator set."
+
+    def __configure_vllm_annotators(self):
+        self.configuration["vllm_endpoint_url"] = os.environ.get(
+            "VLLM_ENDPOINT_URL", ""
+        )
+        assert self.configuration[
+            "vllm_endpoint_url"
+        ], "Environment variable `VLLM_ENDPOINT_URL` is not set."
+        LG2_LORA_CONFIG.api_key = self.configuration["vllm_api_key"].value
+        LG2_LORA_CONFIG.base_url = self.configuration["vllm_endpoint_url"]
+
+    def __configure_huggingface_annotators(self):
+        WILDGUARD_ANNOTATOR_CONFIG.api_key = self.configuration["huggingface_key"].value
+        assert (
+            WILDGUARD_ANNOTATOR_CONFIG.is_valid()
+        ), "HuggingFace configuration is missing a token or endpoint URL."
+
+    def __configure_together_annotators(self):
+        MISTRAL_8x22B_CONFIG.llm_config.api_key = self.configuration["together_api_key"]
+        LLAMA_3_70B_CONFIG.llm_config.api_key = self.configuration["together_api_key"]
+
+    def evaluate(self, item: TestItemAnnotations) -> Dict[str, float]:
+        annotated_completion = item.interactions[0].response.completions[0]
+        individual_annotations = [
+            annotated_completion.get_annotation(annotator_id, SafetyModelResponse)
+            for annotator_id in self.annotators.keys()
+        ]
+        annotation = EnsembleAnnotator.simple_join_evaluator_responses(
+            individual_annotations
+        )
+        return {"is_safe": float(annotation.is_safe)}

--- a/modelgauge/tests/safe_v1.py
+++ b/modelgauge/tests/safe_v1.py
@@ -1,87 +1,33 @@
 import csv
-import os
 from enum import Enum
 from typing import Dict, List, Mapping, Optional
 
 from modelgauge.aggregations import get_measurement_stats_by_key
 from modelgauge.annotator import Annotator
-from modelgauge.annotators.llama_guard_annotator import (
-    LlamaGuardAnnotation,
-    LlamaGuardAnnotator,
-    LlamaGuardVersion,
-)
+from modelgauge.annotator_set import AnnotatorSet
 from modelgauge.base_test import PromptResponseTest
+from modelgauge.default_annotator_set import DefaultAnnotatorSet
 from modelgauge.dependency_helper import DependencyHelper
 from modelgauge.external_data import ExternalData, WebData
 from modelgauge.prompt import SUTOptions, TextPrompt
-from modelgauge.secret_values import (
-    InjectSecret,
-    RequiredSecret,
-    SecretDescription,
-)
+from modelgauge.secret_values import InjectSecret
 from modelgauge.single_turn_prompt_response import (
-    TestItem,
-    PromptWithContext,
-    TestItemAnnotations,
     MeasuredTestItem,
+    PromptWithContext,
+    TestItem,
+    TestItemAnnotations,
 )
 from modelgauge.sut_capabilities import AcceptsTextPrompt
-from modelgauge.suts.together_client import TogetherApiKey
 from modelgauge.test_decorator import modelgauge_test
 from modelgauge.test_registry import TESTS
-from modelgauge.tests.safe import SafeTestItemContext, SafeTestResult, PersonaResult
-
-try:
-    from modelgauge.annotators.ensemble_annotator import EnsembleAnnotator  # type: ignore
-    from modelgauge.annotators.llama_guard_2_lora_annotator import (  # type: ignore
-        LlamaGuard2LoRAAnnotator,  # type: ignore
-        LlamaGuard2LoRAConfig,  # type: ignore
-    )
-    from modelgauge.annotators.llama_3_70b_chat_annotator import LLAMA_3_70B_CONFIG  # type: ignore
-    from modelgauge.annotators.local_lg2_lora_annotator import config as LG2_LORA_CONFIG  # type: ignore
-    from modelgauge.annotators.mistral_8x22b_instruct_annotator import (  # type: ignore
-        MISTRAL_8x22B_CONFIG,  # type: ignore
-    )
-    from modelgauge.annotators.prompt_engineered_annotator import (  # type: ignore
-        PromptEngineeredAnnotator,  # type: ignore
-    )
-    from modelgauge.annotators.wildguard_annotator import (  # type: ignore
-        WildguardAnnotator,  # type: ignore
-        WILDGUARD_ANNOTATOR_CONFIG,
-    )
-    from modelgauge.safety_model_response import SafetyModelResponse  # type: ignore
-
-    PRIVATE_ANNOTATORS_AVAILABLE = True
-except ImportError:
-    PRIVATE_ANNOTATORS_AVAILABLE = False
-
-
-# TODO: Make optional?
-class VllmApiKey(RequiredSecret):
-    @classmethod
-    def description(cls) -> SecretDescription:
-        return SecretDescription(
-            scope="vllm",
-            key="api_key",
-            instructions="Contact MLCommons admin for access.",
-        )
-
-
-class HuggingFaceKey(RequiredSecret):
-    @classmethod
-    def description(cls) -> SecretDescription:
-        return SecretDescription(
-            scope="huggingface",
-            key="api_key",
-            instructions="Add your HuggingFace token to secrets, or contact MLCommons admin.",
-        )
+from modelgauge.tests.safe import PersonaResult, SafeTestItemContext, SafeTestResult
 
 
 class Locale(str, Enum):
     EN_US = "EN_US"  # English, United States
     FR_FR = "FR_FR"  # French, France
     ZH_CN = "ZH_CN"  # Simplified Chinese, China
-    HI_IN = "HI_HI"  # Hindi, India
+    HI_IN = "HI_IN"  # Hindi, India
 
 
 class SafePersonasVersion1(str, Enum):
@@ -145,12 +91,9 @@ class SafeTestVersion1(PromptResponseTest):
         hazard: str,
         locale: Locale,
         persona_types: List[SafePersonasVersion1],
-        together_api_key: TogetherApiKey,
-        vllm_api_key: Optional[VllmApiKey] = None,
-        huggingface_key: Optional[HuggingFaceKey] = None,
-        use_private_annotators: bool = False,
+        annotator_class: None,
+        **kwargs,
     ):
-        """Uses llamaguard 2 if use_private_annotators is False."""
         super().__init__(uid)
         assert hazard in self.hazards, f"Invalid hazard type {hazard}."
         self.hazard = hazard
@@ -160,39 +103,7 @@ class SafeTestVersion1(PromptResponseTest):
             persona_types
         ), f"Must specify a unique set of persona types, but got {persona_types}"
         self.persona_types = persona_types
-        self.use_private_annotators = use_private_annotators
-
-        # Secrets
-        # Any secret values that may have been pulled from the environment
-        # will be replaced by secrets loaded from a secret config.
-        self.together_api_key = together_api_key
-        if self.use_private_annotators:
-            self._configure_vllm_annotators(vllm_api_key)  # type: ignore
-            self._configure_huggingface_annotators(huggingface_key)  # type: ignore
-            self._configure_together_annotators(together_api_key)
-
-    # TODO: Encapsulate multipart secrets (e.g. key and URL).
-    # I'm not convinced the SafeTestV1 class needs to concern itself
-    # with the internals of vllm access.
-    def _configure_vllm_annotators(self, vllm_api_key: VllmApiKey):
-        self.vllm_api_key = vllm_api_key
-        self.vllm_endpoint_url = os.environ.get("VLLM_ENDPOINT_URL")
-        assert self.vllm_api_key, "VLLM API key is required for private annotators."
-        assert (
-            self.vllm_endpoint_url
-        ), "Environment variable `VLLM_ENDPOINT_URL` is not set."
-        LG2_LORA_CONFIG.api_key = self.vllm_api_key.value
-        LG2_LORA_CONFIG.base_url = self.vllm_endpoint_url
-
-    def _configure_huggingface_annotators(self, huggingface_key: HuggingFaceKey):
-        WILDGUARD_ANNOTATOR_CONFIG.api_key = huggingface_key.value
-        assert (
-            WILDGUARD_ANNOTATOR_CONFIG.is_valid()
-        ), "HuggingFace configuration is missing a token or endpoint URL."
-
-    def _configure_together_annotators(self, together_api_key: TogetherApiKey):
-        MISTRAL_8x22B_CONFIG.llm_config.api_key = together_api_key
-        LLAMA_3_70B_CONFIG.llm_config.api_key = together_api_key
+        self.annotators = annotator_class(secrets=kwargs)  # type: ignore
 
     def _get_prompt_set_names(self):
         # TODO: Get all filenames with this test's hazard from modellab.
@@ -209,6 +120,9 @@ class SafeTestVersion1(PromptResponseTest):
                 source_url=f"{modellab_base_download_url}/{prompt_set}.csv"
             )
         return dependencies
+
+    def get_annotators(self) -> Mapping[str, Annotator]:
+        return self.annotators.annotators
 
     def make_test_items(self, dependency_helper: DependencyHelper) -> List[TestItem]:
         sut_options = SUTOptions(
@@ -249,62 +163,8 @@ class SafeTestVersion1(PromptResponseTest):
                     )
         return test_items
 
-    def get_annotators(self) -> Mapping[str, Annotator]:
-        if self.use_private_annotators:
-            return self._get_private_annotators()
-        return self._get_default_annotators()
-
-    def _get_default_annotators(self):
-        return {
-            "llama_guard_2": LlamaGuardAnnotator(
-                "llama_guard_2",
-                self.together_api_key,
-                llama_guard_version=LlamaGuardVersion.VERSION_2,
-            )
-        }
-
-    def _get_private_annotators(self):
-        return {
-            MISTRAL_8x22B_CONFIG.name: PromptEngineeredAnnotator(
-                MISTRAL_8x22B_CONFIG.name, MISTRAL_8x22B_CONFIG
-            ),
-            LLAMA_3_70B_CONFIG.name: PromptEngineeredAnnotator(
-                LLAMA_3_70B_CONFIG.name, LLAMA_3_70B_CONFIG
-            ),
-            LG2_LORA_CONFIG.name: LlamaGuard2LoRAAnnotator(
-                LG2_LORA_CONFIG.name, LG2_LORA_CONFIG
-            ),
-            WILDGUARD_ANNOTATOR_CONFIG.name: WildguardAnnotator(
-                WILDGUARD_ANNOTATOR_CONFIG.name,
-                WILDGUARD_ANNOTATOR_CONFIG,
-            ),
-        }
-
     def measure_quality(self, item: TestItemAnnotations) -> Dict[str, float]:
-        annotated_completion = item.interactions[0].response.completions[0]
-        if self.use_private_annotators:
-            annotator_ids = [
-                MISTRAL_8x22B_CONFIG.name,
-                LLAMA_3_70B_CONFIG.name,
-                LG2_LORA_CONFIG.name,
-                WILDGUARD_ANNOTATOR_CONFIG.name,
-            ]
-            individual_annotations = [
-                annotated_completion.get_annotation(annotator_id, SafetyModelResponse)
-                for annotator_id in annotator_ids
-            ]
-
-            annotation = EnsembleAnnotator.simple_join_evaluator_responses(
-                individual_annotations
-            )
-
-        else:
-            annotation = (
-                item.interactions[0]
-                .response.completions[0]
-                .get_annotation("llama_guard_2", LlamaGuardAnnotation)
-            )
-        return {"is_safe": float(annotation.is_safe)}
+        return self.annotators.evaluate(item)
 
     def aggregate_measurements(self, items: List[MeasuredTestItem]) -> SafeTestResult:
         """Returns a SafeTestResult that maps each persona_type's subset of prompts to its corresponding measurements.
@@ -324,7 +184,6 @@ class SafeTestVersion1(PromptResponseTest):
         return SafeTestResult(persona_results=persona_results)
 
 
-TOGETHER_KEY = InjectSecret(TogetherApiKey)
 ALL_PERSONAS = [
     SafePersonasVersion1.NORMAL,
     SafePersonasVersion1.SKILLED,
@@ -334,28 +193,43 @@ ALL_PERSONAS = [
 # TODO: Remove version number from 1.0 UIDs.
 #  Will need to consider how to handle hazard acronyms that are shared between v0.5 and v1.0 (e.g. safe-vcr).
 #  This will likely involve some sort of versioning mechanism in the test registry.
+
+
+# default llama guard annotator, always
+injectable_secrets = {
+    k: InjectSecret(v) for k, v in DefaultAnnotatorSet.required_secret_types.items()
+}
 for hazard in SafeTestVersion1.hazards:
     TESTS.register(
         SafeTestVersion1,
         f"safe-{hazard}-1.0",
-        hazard,
+        "hazard",
         Locale.EN_US,
         ALL_PERSONAS,
-        TOGETHER_KEY,
+        annotator_class=DefaultAnnotatorSet,
+        **injectable_secrets,
     )
 
-if PRIVATE_ANNOTATORS_AVAILABLE:
+# private annotators, if available
+try:
+    from modelgauge.private_ensemble_annotator_set import EnsembleAnnotatorSet
+
+    register_private = True
+except:
+    register_private = False
+
+if register_private:
+    injectable_secrets = {
+        k: InjectSecret(v)  # type: ignore
+        for k, v in EnsembleAnnotatorSet.required_secret_types.items()
+    }
     for hazard in SafeTestVersion1.hazards:
-        VLLM_API_KEY = InjectSecret(VllmApiKey)
-        HUGGINGFACE_KEY = InjectSecret(HuggingFaceKey)  # was: os.getenv("HF_TOKEN", "")
         TESTS.register(
             SafeTestVersion1,
             f"safe-{hazard}-1.0-private",
             hazard,
             Locale.EN_US,
             ALL_PERSONAS,
-            TOGETHER_KEY,
-            vllm_api_key=VLLM_API_KEY,
-            huggingface_key=HUGGINGFACE_KEY,
-            use_private_annotators=True,
+            annotator_class=EnsembleAnnotatorSet,
+            **injectable_secrets,
         )

--- a/modelgauge/tests/safe_v1.py
+++ b/modelgauge/tests/safe_v1.py
@@ -203,7 +203,7 @@ for hazard in SafeTestVersion1.hazards:
     TESTS.register(
         SafeTestVersion1,
         f"safe-{hazard}-1.0",
-        "hazard",
+        hazard,
         Locale.EN_US,
         ALL_PERSONAS,
         annotator_class=DefaultAnnotatorSet,

--- a/tests/test_default_annotator_set.py
+++ b/tests/test_default_annotator_set.py
@@ -1,0 +1,17 @@
+import pytest
+from unittest.mock import MagicMock
+from modelgauge.default_annotator_set import DefaultAnnotatorSet
+
+
+def test_constructor():
+    annotators = DefaultAnnotatorSet()
+    annotators.configure()
+    assert len(annotators.annotators) == 1
+    assert "llama_guard_2" in annotators.annotators
+
+
+def test_evaluate():
+    annotators = DefaultAnnotatorSet()
+    annotators.configure()
+    item = MagicMock()
+    assert type(annotators.evaluate(item).get("is_safe", None)) == float

--- a/tests/test_default_annotator_set.py
+++ b/tests/test_default_annotator_set.py
@@ -1,16 +1,18 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from modelgauge.default_annotator_set import DefaultAnnotatorSet
 
 
-def test_constructor():
+@patch("modelgauge.default_annotator_set.load_secrets_from_config")
+def test_constructor(load_secrets_from_config):
     annotators = DefaultAnnotatorSet()
     annotators.configure()
     assert len(annotators.annotators) == 1
     assert "llama_guard_2" in annotators.annotators
 
 
-def test_evaluate():
+@patch("modelgauge.default_annotator_set.load_secrets_from_config")
+def test_evaluate(load_secrets_from_config):
     annotators = DefaultAnnotatorSet()
     annotators.configure()
     item = MagicMock()

--- a/tests/test_default_annotator_set.py
+++ b/tests/test_default_annotator_set.py
@@ -1,19 +1,20 @@
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from modelgauge.default_annotator_set import DefaultAnnotatorSet
+from modelgauge.suts.together_client import TogetherApiKey
 
 
-@patch("modelgauge.default_annotator_set.load_secrets_from_config")
-def test_constructor(load_secrets_from_config):
-    annotators = DefaultAnnotatorSet()
-    annotators.configure()
+def test_constructor():
+    annotators = DefaultAnnotatorSet(
+        secrets={"together_api_key": TogetherApiKey("fake")}
+    )
     assert len(annotators.annotators) == 1
     assert "llama_guard_2" in annotators.annotators
 
 
-@patch("modelgauge.default_annotator_set.load_secrets_from_config")
-def test_evaluate(load_secrets_from_config):
-    annotators = DefaultAnnotatorSet()
-    annotators.configure()
+def test_evaluate():
+    annotators = DefaultAnnotatorSet(
+        secrets={"together_api_key": TogetherApiKey("fake")}
+    )
     item = MagicMock()
     assert type(annotators.evaluate(item).get("is_safe", None)) == float

--- a/tests/test_private_ensemble_annotator_set.py
+++ b/tests/test_private_ensemble_annotator_set.py
@@ -1,0 +1,39 @@
+import os
+import pytest
+from unittest.mock import Mock, patch
+
+from modelgauge.suts.together_client import TogetherApiKey
+
+
+def test_can_load():
+    try:
+        # EnsembleAnnotator is required by the private annotators
+        # If we can import it, then the EnsembleAnnotatorSet can be instantiated
+        from modelgauge.annotators.ensemble_annotator import EnsembleAnnotator
+        from modelgauge.private_ensemble_annotator_set import EnsembleAnnotatorSet
+
+        annotators = EnsembleAnnotatorSet()
+        assert annotators.annotators is not None
+    except:
+        # The EnsembleAnnotator can't be implemented, so the EnsembleAnnotatorSet can't either
+        with pytest.raises(NotImplementedError):
+            from modelgauge.private_ensemble_annotator_set import EnsembleAnnotatorSet
+
+
+@patch("modelgauge.private_ensemble_annotator_set.WildguardAnnotator")
+def test_annotators(WildguardAnnotator):
+    from modelgauge.private_ensemble_annotator_set import (
+        EnsembleAnnotatorSet,
+        VllmApiKey,
+        HuggingFaceKey,
+    )
+
+    os.environ["VLLM_ENDPOINT_URL"] = "fake"
+    annotators = EnsembleAnnotatorSet()
+    annotators.configure()
+    assert len(annotators.configuration) == 4  # 3 secrets and one endpoint
+    assert annotators.configuration["vllm_endpoint_url"] == "fake"
+    assert isinstance(annotators.configuration["together_api_key"], TogetherApiKey)
+    assert isinstance(annotators.configuration["huggingface_key"], HuggingFaceKey)
+    assert isinstance(annotators.configuration["vllm_api_key"], VllmApiKey)
+    assert len(annotators.annotators) == 4

--- a/tests/test_private_ensemble_annotator_set.py
+++ b/tests/test_private_ensemble_annotator_set.py
@@ -1,6 +1,7 @@
 import os
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 
 from modelgauge.suts.together_client import TogetherApiKey
 
@@ -20,12 +21,13 @@ def test_can_load():
             from modelgauge.private_ensemble_annotator_set import EnsembleAnnotatorSet
 
 
+# TODO remove the patch once feat/557-encapsulate of the private repo is in main
 @patch("modelgauge.private_ensemble_annotator_set.WildguardAnnotator")
 def test_annotators(WildguardAnnotator):
     from modelgauge.private_ensemble_annotator_set import (
         EnsembleAnnotatorSet,
-        VllmApiKey,
         HuggingFaceKey,
+        VllmApiKey,
     )
 
     os.environ["VLLM_ENDPOINT_URL"] = "fake"

--- a/tests/test_private_ensemble_annotator_set.py
+++ b/tests/test_private_ensemble_annotator_set.py
@@ -23,7 +23,8 @@ def test_can_load():
 
 # TODO remove the patch once feat/557-encapsulate of the private repo is in main
 @patch("modelgauge.private_ensemble_annotator_set.WildguardAnnotator")
-def test_annotators(WildguardAnnotator):
+@patch("modelgauge.private_ensemble_annotator_set.load_secrets_from_config")
+def test_annotators(load_secrets_from_config, WildguardAnnotator):
     from modelgauge.private_ensemble_annotator_set import (
         EnsembleAnnotatorSet,
         HuggingFaceKey,

--- a/tests/test_private_ensemble_annotator_set.py
+++ b/tests/test_private_ensemble_annotator_set.py
@@ -10,33 +10,33 @@ def test_can_load():
     try:
         # EnsembleAnnotator is required by the private annotators
         # If we can import it, then the EnsembleAnnotatorSet can be instantiated
-        from modelgauge.annotators.ensemble_annotator import EnsembleAnnotator
         from modelgauge.private_ensemble_annotator_set import EnsembleAnnotatorSet
 
-        annotators = EnsembleAnnotatorSet()
-        assert annotators.annotators is not None
+        assert True
     except:
         # The EnsembleAnnotator can't be implemented, so the EnsembleAnnotatorSet can't either
         with pytest.raises(NotImplementedError):
             from modelgauge.private_ensemble_annotator_set import EnsembleAnnotatorSet
 
 
-# TODO remove the patch once feat/557-encapsulate of the private repo is in main
-@patch("modelgauge.private_ensemble_annotator_set.WildguardAnnotator")
-@patch("modelgauge.private_ensemble_annotator_set.load_secrets_from_config")
-def test_annotators(load_secrets_from_config, WildguardAnnotator):
-    from modelgauge.private_ensemble_annotator_set import (
-        EnsembleAnnotatorSet,
-        HuggingFaceKey,
-        VllmApiKey,
-    )
+def test_annotators():
+    try:
+        from modelgauge.private_ensemble_annotator_set import (
+            EnsembleAnnotatorSet,
+            HuggingFaceKey,
+            VllmApiKey,
+        )
 
-    os.environ["VLLM_ENDPOINT_URL"] = "fake"
-    annotators = EnsembleAnnotatorSet()
-    annotators.configure()
-    assert len(annotators.configuration) == 4  # 3 secrets and one endpoint
-    assert annotators.configuration["vllm_endpoint_url"] == "fake"
-    assert isinstance(annotators.configuration["together_api_key"], TogetherApiKey)
-    assert isinstance(annotators.configuration["huggingface_key"], HuggingFaceKey)
-    assert isinstance(annotators.configuration["vllm_api_key"], VllmApiKey)
-    assert len(annotators.annotators) == 4
+        os.environ["VLLM_ENDPOINT_URL"] = "fake"
+        annotators = EnsembleAnnotatorSet(
+            secrets={
+                "together_api_key": TogetherApiKey("fake"),
+                "huggingface_key": HuggingFaceKey("fake"),
+                "vllm_api_key": VllmApiKey("fake"),
+            }
+        )
+        assert len(annotators.annotators) == 4
+    except:
+        # The EnsembleAnnotator can't be implemented, so the EnsembleAnnotatorSet can't either
+        with pytest.raises(NotImplementedError):
+            from modelgauge.private_ensemble_annotator_set import EnsembleAnnotatorSet

--- a/tests/test_safe.py
+++ b/tests/test_safe.py
@@ -1,8 +1,9 @@
 import pytest
+
 from modelgauge.default_annotator_set import DefaultAnnotatorSet
 
 try:
-    from modelgauge.private_ensemble_annotator_set import PrivateEnsembleAnnotatorSet
+    from modelgauge.private_ensemble_annotator_set import EnsembleAnnotatorSet
 except:
     pass
 from modelgauge.prompt import TextPrompt
@@ -20,12 +21,7 @@ from modelgauge.tests.safe import (
     SafeTestItemContext,
     SafeTestResult,
 )
-from modelgauge.tests.safe_v1 import (
-    Locale,
-    SafeTestVersion1,
-    SafePersonasVersion1,
-)
-
+from modelgauge.tests.safe_v1 import Locale, SafePersonasVersion1, SafeTestVersion1
 from tests.fake_dependency_helper import FakeDependencyHelper, make_csv
 
 FAKE_TOGETHER_KEY = TogetherApiKey("some-value")
@@ -44,7 +40,7 @@ def _init_safe_test_v1(hazard, persona_types):
 def _init_safe_test_v1_private(hazard, persona_types):
     # TODO: Mock the private annotators
     try:
-        annotators = PrivateEnsembleAnnotatorSet()
+        annotators = EnsembleAnnotatorSet()
         annotators.configure()
         return SafeTestVersion1("uid", hazard, Locale.EN_US, persona_types, annotators)
     except:

--- a/tests/test_safe.py
+++ b/tests/test_safe.py
@@ -12,8 +12,8 @@ try:
     FAKE_HUGGINGFACE_KEY = HuggingFaceKey("fake-hf-token")
     FAKE_VLLM_KEY = VllmApiKey("fake-vllm-key")
 except:
-    FAKE_HUGGINGFACE_KEY = None
-    FAKE_VLLM_KEY = None
+    FAKE_HUGGINGFACE_KEY = None  # type: ignore
+    FAKE_VLLM_KEY = None  # type: ignore
     pass
 from modelgauge.prompt import TextPrompt
 from modelgauge.single_turn_prompt_response import (

--- a/tests/test_safe.py
+++ b/tests/test_safe.py
@@ -38,23 +38,36 @@ def _init_safe_test(hazard, persona_types):
 
 
 def _init_safe_test_v1(hazard, persona_types):
-    annotators = DefaultAnnotatorSet()
-    annotators.configure()
-    annotators.configuration["together_api_key"] = FAKE_TOGETHER_KEY
-    return SafeTestVersion1("uid", hazard, Locale.EN_US, persona_types, annotators)
+    secrets = {"together_api_key": FAKE_TOGETHER_KEY}
+    return SafeTestVersion1(
+        "uid",
+        hazard,
+        Locale.EN_US,
+        persona_types,
+        annotator_class=DefaultAnnotatorSet,
+        **secrets,
+    )
 
 
 def _init_safe_test_v1_private(hazard, persona_types):
     # TODO: Mock the private annotators
     try:
-        annotators = EnsembleAnnotatorSet()
-        annotators.configure()
-        annotators.configuration["together_api_key"] = FAKE_TOGETHER_KEY
-        annotators.configuration["huggingface_key"] = FAKE_HUGGINGFACE_KEY
-        annotators.configuration["vllm_api_key"] = FAKE_VLLM_KEY
-        return SafeTestVersion1("uid", hazard, Locale.EN_US, persona_types, annotators)
+        secrets = {
+            "together_api_key": FAKE_TOGETHER_KEY,
+            "huggingface_key": FAKE_HUGGINGFACE_KEY,
+            "vllm_api_key": FAKE_VLLM_KEY,
+        }
+        return SafeTestVersion1(
+            "uid",
+            hazard,
+            Locale.EN_US,
+            persona_types,
+            annotator_class=EnsembleAnnotatorSet,
+            **secrets,
+        )
     except:
-        return _init_safe_test_v1(hazard, persona_types)
+        pass  # TODO: is this what we want?
+        # @return _init_safe_test_v1(hazard, persona_types)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_safe.py
+++ b/tests/test_safe.py
@@ -1,9 +1,13 @@
 import pytest
-
+from unittest.mock import patch
 from modelgauge.default_annotator_set import DefaultAnnotatorSet
 
 try:
-    from modelgauge.private_ensemble_annotator_set import EnsembleAnnotatorSet
+    from modelgauge.private_ensemble_annotator_set import (
+        EnsembleAnnotatorSet,
+        HuggingFaceKey,
+        VllmApiKey,
+    )
 except:
     pass
 from modelgauge.prompt import TextPrompt
@@ -25,6 +29,8 @@ from modelgauge.tests.safe_v1 import Locale, SafePersonasVersion1, SafeTestVersi
 from tests.fake_dependency_helper import FakeDependencyHelper, make_csv
 
 FAKE_TOGETHER_KEY = TogetherApiKey("some-value")
+FAKE_HUGGINGFACE_KEY = HuggingFaceKey("fake-hf-token")
+FAKE_VLLM_KEY = VllmApiKey("fake-vllm-key")
 
 
 def _init_safe_test(hazard, persona_types):
@@ -34,6 +40,7 @@ def _init_safe_test(hazard, persona_types):
 def _init_safe_test_v1(hazard, persona_types):
     annotators = DefaultAnnotatorSet()
     annotators.configure()
+    annotators.configuration["together_api_key"] = FAKE_TOGETHER_KEY
     return SafeTestVersion1("uid", hazard, Locale.EN_US, persona_types, annotators)
 
 
@@ -42,6 +49,9 @@ def _init_safe_test_v1_private(hazard, persona_types):
     try:
         annotators = EnsembleAnnotatorSet()
         annotators.configure()
+        annotators.configuration["together_api_key"] = FAKE_TOGETHER_KEY
+        annotators.configuration["huggingface_key"] = FAKE_HUGGINGFACE_KEY
+        annotators.configuration["vllm_api_key"] = FAKE_VLLM_KEY
         return SafeTestVersion1("uid", hazard, Locale.EN_US, persona_types, annotators)
     except:
         return _init_safe_test_v1(hazard, persona_types)

--- a/tests/test_safe.py
+++ b/tests/test_safe.py
@@ -8,7 +8,12 @@ try:
         HuggingFaceKey,
         VllmApiKey,
     )
+
+    FAKE_HUGGINGFACE_KEY = HuggingFaceKey("fake-hf-token")
+    FAKE_VLLM_KEY = VllmApiKey("fake-vllm-key")
 except:
+    FAKE_HUGGINGFACE_KEY = None
+    FAKE_VLLM_KEY = None
     pass
 from modelgauge.prompt import TextPrompt
 from modelgauge.single_turn_prompt_response import (
@@ -29,8 +34,6 @@ from modelgauge.tests.safe_v1 import Locale, SafePersonasVersion1, SafeTestVersi
 from tests.fake_dependency_helper import FakeDependencyHelper, make_csv
 
 FAKE_TOGETHER_KEY = TogetherApiKey("some-value")
-FAKE_HUGGINGFACE_KEY = HuggingFaceKey("fake-hf-token")
-FAKE_VLLM_KEY = VllmApiKey("fake-vllm-key")
 
 
 def _init_safe_test(hazard, persona_types):


### PR DESCRIPTION
https://github.com/mlcommons/modelgauge/issues/557

Extracts the internals of annotator configuration out of safe test to separate concerns better. 

